### PR TITLE
Add GitHub issue templates for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Create a report to help us improve
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report for Worlds! Fill out the following form to your best ability to help us fix the problem.
+        Only use this if you're absolutely sure that you found a bug and can reproduce it. For anything else, use: [our Discord server](https://thenextlvl.net/discord).
+
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce this behaviour
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behaviour
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Screenshots / Videos
+      description: If applicable, add screenshots to help explain your problem.
+
+  - type: input
+    attributes:
+      label: Error log (if applicable)
+      description: If you are reporting a console error, upload any relevant log excerpts to either https://paste.gg/ or https://gist.github.com, save and the paste the link in this box.
+
+  - type: input
+    attributes:
+      label: Worlds Version
+      description: What version of World are you running? (`/version World`)
+      placeholder: "For example: version 1.1.0"
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      description: Make sure you have followed each of the steps outlined here.
+      options:
+        - label: I am using the newest build from https://github.com/TheNextLvl-net/worlds and the issue still persists.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: You can provide additional context below.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Suggest an idea for this project
+labels: 'enhancement'
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request for Worlds! Fill out the following form to your best 
+          ability to help us understand your feature request and greatly improve the change of it getting added.
+        For anything else than a feature request, use: [our Discord server](https://thenextlvl.net/discord).
+
+  - type: textarea
+    attributes:
+      label: What feature do you want to see added?
+      description: A clear and concise description of your feature request.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Are there any alternatives?
+      description: List any alternatives you might have tried
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: You can provide additional context below.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+daysUntilStale: 30
+daysUntilClose: 7
+only: issues
+exemptLabels:
+  - "Bug"
+  - "Enhancement"
+  - "Approved"
+  - "Priority"
+  - "Under investigation"
+staleLabel: "resolution: stale"
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. If the issue is still present and can be reproduced, please let the team know.
+  Thank you for your contributions.
+closeComment: >
+  This issue has been automatically closed because it has not had activity in
+  a long time. If the issue still applies to the most recent supported
+  version, please reply to this issue and the team will reopen it.


### PR DESCRIPTION
Introduce standardized issue templates for bug reports and feature requests to enhance the clarity and organization of received issues. Also, add a configuration file to automatically stale and close inactive issues.