### PR TITLE
Upgrade Paper dependency and streamline version checker

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     implementation("net.thenextlvl.core:nbt:1.4.2")
     implementation("net.thenextlvl.core:files:1.0.5")
     implementation("net.thenextlvl.core:i18n:1.0.19")
-    implementation("net.thenextlvl.core:paper:1.4.1")
+    implementation("net.thenextlvl.core:paper:1.5.2")
     implementation("net.thenextlvl.core:adapters:1.0.9")
 
     annotationProcessor("org.projectlombok:lombok:1.18.34")

--- a/plugin/src/main/java/net/thenextlvl/worlds/version/PluginVersionChecker.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/version/PluginVersionChecker.java
@@ -2,40 +2,16 @@ package net.thenextlvl.worlds.version;
 
 import core.paper.version.PaperHangarVersionChecker;
 import core.version.SemanticVersion;
-import lombok.Getter;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Objects;
-
-@Getter
-@SuppressWarnings("UnstableApiUsage")
 public class PluginVersionChecker extends PaperHangarVersionChecker<SemanticVersion> {
-    private final SemanticVersion versionRunning;
-    private final Plugin plugin;
-
     public PluginVersionChecker(Plugin plugin) {
-        super("Worlds");
-        this.plugin = plugin;
-        this.versionRunning = Objects.requireNonNull(parseVersion(plugin.getPluginMeta().getVersion()));
+        super(plugin, "TheNextLvl", "Worlds");
     }
 
     @Override
     public @Nullable SemanticVersion parseVersion(String version) {
         return SemanticVersion.parse(version);
-    }
-
-    public void checkVersion() {
-        retrieveLatestSupportedVersion(latest -> latest.ifPresentOrElse(version -> {
-            if (version.equals(getVersionRunning())) {
-                plugin.getComponentLogger().info("You are running the latest version of Worlds");
-            } else if (version.compareTo(getVersionRunning()) > 0) {
-                plugin.getComponentLogger().warn("An update for Worlds is available");
-                plugin.getComponentLogger().warn("You are running version {}, the latest supported version is {}", getVersionRunning(), version);
-                plugin.getComponentLogger().warn("Update at https://modrinth.com/plugin/worlds-1 or https://hangar.papermc.io/TheNextLvl/Worlds");
-            } else {
-                plugin.getComponentLogger().warn("You are running a snapshot version of Worlds");
-            }
-        }, () -> plugin.getComponentLogger().error("Version check failed")));
     }
 }


### PR DESCRIPTION
Updated the 'net.thenextlvl.core:paper' dependency to version 1.5.2. Simplified the `PluginVersionChecker` by removing redundant fields and the` method. This aligns the codebase with the latest API adjustments and improves maintainability.