### PR TITLE
Add persistence for cloned worlds

### DIFF
--- a/plugin/src/main/java/net/thenextlvl/worlds/command/WorldCloneCommand.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/command/WorldCloneCommand.java
@@ -44,6 +44,8 @@ class WorldCloneCommand {
         var key = context.getArgument("key", NamespacedKey.class);
         var clone = clone(world, key, full);
 
+        if (clone != null) plugin.persistWorld(clone, true);
+
         var placeholder = Placeholder.parsed("world", world.getName());
         var message = clone != null ? "world.clone.success" : "world.clone.failed";
 


### PR DESCRIPTION
Ensure cloned worlds are persisted immediately after creation by calling `plugin.persistWorld(clone, true)` if the clone operation is successful. This change prevents potential loss of data for newly cloned worlds.
This prevents a potential bug causing two worlds with the same key to be loaded.