### PR TITLE
Add Folia compatibility and refactor world creation

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -27,10 +27,11 @@ repositories {
     maven("https://repo.thenextlvl.net/releases")
     maven("https://repo.thenextlvl.net/snapshots")
     maven("https://repo.papermc.io/repository/maven-public/")
+    maven("https://github.com/Folia-Inquisitors/FoliaDevBundle/raw/gh-pages/")
 }
 
 dependencies {
-    paperweight.paperDevBundle("1.21.3-R0.1-SNAPSHOT")
+    paperweight.foliaDevBundle("1.21.1-R0.1-SNAPSHOT")
 
     compileOnly("org.projectlombok:lombok:1.18.34")
 
@@ -61,6 +62,7 @@ paper {
     load = BukkitPluginDescription.PluginLoadOrder.STARTUP
     website = "https://thenextlvl.net"
     authors = listOf("NonSwag")
+    foliaSupported = true
 
     permissions {
         register("worlds.commands.admin") {

--- a/plugin/src/main/java/net/thenextlvl/worlds/WorldsPlugin.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/WorldsPlugin.java
@@ -61,6 +61,8 @@ public class WorldsPlugin extends JavaPlugin implements WorldsProvider {
     private final PluginVersionChecker versionChecker = new PluginVersionChecker(this);
     private final Metrics metrics = new Metrics(this, 19652);
 
+    private final boolean foliaCompatible = folia();
+
     @Override
     public void onLoad() {
         if (!presetsFolder().isDirectory()) saveDefaultPresets();
@@ -132,5 +134,14 @@ public class WorldsPlugin extends JavaPlugin implements WorldsProvider {
         Presets.THE_VOID.saveToFile(new File(presetsFolder(), "the-void.json"), true);
         Presets.TUNNELERS_DREAM.saveToFile(new File(presetsFolder(), "tunnelers-dream.json"), true);
         Presets.WATER_WORLD.saveToFile(new File(presetsFolder(), "water-world.json"), true);
+    }
+
+    private boolean folia() {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
     }
 }

--- a/plugin/src/main/java/net/thenextlvl/worlds/model/FoliaLevel.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/model/FoliaLevel.java
@@ -1,0 +1,241 @@
+package net.thenextlvl.worlds.model;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.mojang.serialization.Dynamic;
+import com.mojang.serialization.Lifecycle;
+import net.kyori.adventure.util.TriState;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.nbt.NbtException;
+import net.minecraft.nbt.ReportedNbtException;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.Main;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.WorldLoader;
+import net.minecraft.server.dedicated.DedicatedServerProperties;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.util.datafix.DataFixers;
+import net.minecraft.world.Difficulty;
+import net.minecraft.world.entity.ai.village.VillageSiege;
+import net.minecraft.world.entity.npc.CatSpawner;
+import net.minecraft.world.entity.npc.WanderingTraderSpawner;
+import net.minecraft.world.level.*;
+import net.minecraft.world.level.biome.BiomeManager;
+import net.minecraft.world.level.dimension.LevelStem;
+import net.minecraft.world.level.levelgen.PatrolSpawner;
+import net.minecraft.world.level.levelgen.PhantomSpawner;
+import net.minecraft.world.level.levelgen.WorldDimensions;
+import net.minecraft.world.level.levelgen.WorldOptions;
+import net.minecraft.world.level.storage.LevelDataAndDimensions;
+import net.minecraft.world.level.storage.LevelStorageSource;
+import net.minecraft.world.level.storage.LevelSummary;
+import net.minecraft.world.level.storage.PrimaryLevelData;
+import net.minecraft.world.level.validation.ContentValidationException;
+import net.thenextlvl.worlds.WorldsPlugin;
+import net.thenextlvl.worlds.api.model.LevelBuilder;
+import org.bukkit.GameMode;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.craftbukkit.generator.CraftWorldInfo;
+import org.bukkit.event.world.WorldLoadEvent;
+import org.bukkit.generator.BiomeProvider;
+import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.generator.WorldInfo;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+public class FoliaLevel extends PaperLevel {
+    public FoliaLevel(WorldsPlugin plugin, LevelBuilder builder) {
+        super(plugin, builder);
+    }
+
+    @Override
+    protected @Nullable World createWorld(WorldCreator creator) {
+        var server = ((CraftServer) plugin().getServer());
+
+        String name = creator.name();
+        ChunkGenerator generator = creator.generator();
+        BiomeProvider biomeProvider = creator.biomeProvider();
+        File folder = new File(server.getWorldContainer(), name);
+        World world = server.getWorld(name);
+
+        // Paper start
+        World worldByKey = server.getWorld(creator.key());
+        if (world != null || worldByKey != null) {
+            if (world == worldByKey) {
+                return world;
+            }
+            throw new IllegalArgumentException("Cannot create a world with key " + creator.key() + " and name " + name + " one (or both) already match a world that exists");
+        }
+        // Paper end
+
+        if (folder.exists()) {
+            Preconditions.checkArgument(folder.isDirectory(), "File (%s) exists and isn't a folder", name);
+        }
+
+        if (generator == null) {
+            generator = server.getGenerator(name);
+        }
+
+        if (biomeProvider == null) {
+            biomeProvider = server.getBiomeProvider(name);
+        }
+
+        ResourceKey<LevelStem> actualDimension;
+        switch (creator.environment()) {
+            case NORMAL:
+                actualDimension = LevelStem.OVERWORLD;
+                break;
+            case NETHER:
+                actualDimension = LevelStem.NETHER;
+                break;
+            case THE_END:
+                actualDimension = LevelStem.END;
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal dimension (" + creator.environment() + ")");
+        }
+
+        LevelStorageSource.LevelStorageAccess worldSession;
+        try {
+            worldSession = LevelStorageSource.createDefault(server.getWorldContainer().toPath()).validateAndCreateAccess(name, actualDimension);
+        } catch (IOException | ContentValidationException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        Dynamic<?> dynamic;
+        if (worldSession.hasWorldData()) {
+            LevelSummary worldinfo;
+
+            try {
+                dynamic = worldSession.getDataTag();
+                worldinfo = worldSession.getSummary(dynamic);
+            } catch (NbtException | ReportedNbtException | IOException ioexception) {
+                LevelStorageSource.LevelDirectory convertable_b = worldSession.getLevelDirectory();
+
+                MinecraftServer.LOGGER.warn("Failed to load world data from {}", convertable_b.dataFile(), ioexception);
+                MinecraftServer.LOGGER.info("Attempting to use fallback");
+
+                try {
+                    dynamic = worldSession.getDataTagFallback();
+                    worldinfo = worldSession.getSummary(dynamic);
+                } catch (NbtException | ReportedNbtException | IOException ioexception1) {
+                    MinecraftServer.LOGGER.error("Failed to load world data from {}", convertable_b.oldDataFile(), ioexception1);
+                    MinecraftServer.LOGGER.error("Failed to load world data from {} and {}. World files may be corrupted. Shutting down.", convertable_b.dataFile(), convertable_b.oldDataFile());
+                    return null;
+                }
+
+                worldSession.restoreLevelDataFromOld();
+            }
+
+            if (worldinfo.requiresManualConversion()) {
+                MinecraftServer.LOGGER.info("This world must be opened in an older version (like 1.6.4) to be safely converted");
+                return null;
+            }
+
+            if (!worldinfo.isCompatible()) {
+                MinecraftServer.LOGGER.info("This world was created by an incompatible version.");
+                return null;
+            }
+        } else {
+            dynamic = null;
+        }
+
+        boolean hardcore = creator.hardcore();
+
+        PrimaryLevelData worlddata;
+        var console = server.getServer();
+        WorldLoader.DataLoadContext worldloader_a = console.worldLoader;
+        RegistryAccess.Frozen iregistrycustom_dimension = worldloader_a.datapackDimensions();
+        Registry<LevelStem> iregistry = iregistrycustom_dimension.registryOrThrow(Registries.LEVEL_STEM);
+        if (dynamic != null) {
+            LevelDataAndDimensions leveldataanddimensions = LevelStorageSource.getLevelDataAndDimensions(dynamic, worldloader_a.dataConfiguration(), iregistry, worldloader_a.datapackWorldgen());
+
+            worlddata = (PrimaryLevelData) leveldataanddimensions.worldData();
+            iregistrycustom_dimension = leveldataanddimensions.dimensions().dimensionsRegistryAccess();
+        } else {
+            LevelSettings worldsettings;
+            WorldOptions worldoptions = new WorldOptions(creator.seed(), creator.generateStructures(), false);
+            WorldDimensions worlddimensions;
+
+            DedicatedServerProperties.WorldDimensionData properties = new DedicatedServerProperties.WorldDimensionData(GsonHelper.parse((creator.generatorSettings().isEmpty()) ? "{}" : creator.generatorSettings()), creator.type().name().toLowerCase(Locale.ROOT));
+
+            worldsettings = new LevelSettings(name, GameType.byId(server.getDefaultGameMode().getValue()), hardcore, Difficulty.EASY, false, new GameRules(), worldloader_a.dataConfiguration());
+            worlddimensions = properties.create(worldloader_a.datapackWorldgen());
+
+            WorldDimensions.Complete worlddimensions_b = worlddimensions.bake(iregistry);
+            Lifecycle lifecycle = worlddimensions_b.lifecycle().add(worldloader_a.datapackWorldgen().allRegistriesLifecycle());
+
+            worlddata = new PrimaryLevelData(worldsettings, worldoptions, worlddimensions_b.specialWorldProperty(), lifecycle);
+            iregistrycustom_dimension = worlddimensions_b.dimensionsRegistryAccess();
+        }
+        iregistry = iregistrycustom_dimension.registryOrThrow(Registries.LEVEL_STEM);
+        worlddata.customDimensions = iregistry;
+        worlddata.checkName(name);
+        worlddata.setModdedInfo(console.getServerModName(), console.getModdedStatus().shouldReportAsModified());
+
+        if (console.options.has("forceUpgrade")) {
+            Main.forceUpgrade(worldSession, DataFixers.getDataFixer(), console.options.has("eraseCache"), () -> true, iregistrycustom_dimension, console.options.has("recreateRegionFiles"));
+        }
+
+        long j = BiomeManager.obfuscateSeed(worlddata.worldGenOptions().seed()); // Paper - use world seed
+        List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
+        LevelStem worlddimension = iregistry.get(actualDimension);
+
+        WorldInfo worldInfo = new CraftWorldInfo(worlddata, worldSession, creator.environment(), worlddimension.type().value(), worlddimension.generator(), server.getHandle().getServer().registryAccess()); // Paper - Expose vanilla BiomeProvider from WorldInfo
+        if (biomeProvider == null && generator != null) {
+            biomeProvider = generator.getDefaultBiomeProvider(worldInfo);
+        }
+
+        ResourceKey<Level> worldKey;
+        String levelName = console.getProperties().levelName;
+        if (name.equals(levelName + "_nether")) {
+            worldKey = Level.NETHER;
+        } else if (name.equals(levelName + "_the_end")) {
+            worldKey = Level.END;
+        } else {
+            worldKey = ResourceKey.create(Registries.DIMENSION, ResourceLocation.fromNamespaceAndPath(creator.key().namespace(), creator.key().value()));
+        }
+
+        // If set to not keep spawn in memory (changed from default) then adjust rule accordingly
+        if (creator.keepSpawnLoaded() == TriState.FALSE) { // Paper
+            worlddata.getGameRules().getRule(GameRules.RULE_SPAWN_CHUNK_RADIUS).set(0, null);
+        }
+        ServerLevel internal = (ServerLevel) new ServerLevel(console, console.executor, worldSession, worlddata, worldKey, worlddimension, console.progressListenerFactory.create(worlddata.getGameRules().getInt(GameRules.RULE_SPAWN_CHUNK_RADIUS)),
+                worlddata.isDebugWorld(), j, creator.environment() == World.Environment.NORMAL ? list : ImmutableList.of(), true, console.overworld().getRandomSequences(), creator.environment(), generator, biomeProvider);
+
+        if (server.getWorld(name.toLowerCase(Locale.ROOT)) == null) {
+            return null;
+        }
+
+        console.addLevel(internal); // Paper - Put world into worldlist before initing the world; move up
+        console.initWorld(internal, worlddata, worlddata, worlddata.worldGenOptions());
+
+        internal.setSpawnSettings(true, true);
+        // Paper - Put world into worldlist before initing the world; move up
+
+        console.prepareLevels(internal.getChunkSource().chunkMap.progressListener, internal);
+        // Paper - rewrite chunk system
+
+        server.getPluginManager().callEvent(new WorldLoadEvent(internal.getWorld()));
+        return internal.getWorld();
+    }
+
+    public static GameType getGameType(GameMode gameMode) {
+        return switch (gameMode) {
+            case SURVIVAL -> GameType.SURVIVAL;
+            case CREATIVE -> GameType.CREATIVE;
+            case ADVENTURE -> GameType.ADVENTURE;
+            case SPECTATOR -> GameType.SPECTATOR;
+        };
+    }
+}

--- a/plugin/src/main/java/net/thenextlvl/worlds/model/PaperLevel.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/model/PaperLevel.java
@@ -127,6 +127,10 @@ public class PaperLevel implements Level {
         if (generator() != null) creator.generator(generator().generator(creator.name()));
         if (generator() != null) creator.biomeProvider(generator().biomeProvider(creator.name()));
 
-        return Optional.ofNullable(creator.createWorld());
+        return Optional.ofNullable(createWorld(creator));
+    }
+
+    protected @Nullable World createWorld(WorldCreator creator) {
+        return creator.createWorld();
     }
 }

--- a/plugin/src/main/java/net/thenextlvl/worlds/model/PaperLevelBuilder.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/model/PaperLevelBuilder.java
@@ -36,6 +36,6 @@ public class PaperLevelBuilder implements LevelBuilder {
 
     @Override
     public Level build() {
-        return new PaperLevel(plugin, this);
+        return plugin().foliaCompatible() ? new FoliaLevel(plugin, this) : new PaperLevel(plugin, this);
     }
 }

--- a/plugin/src/main/java/net/thenextlvl/worlds/view/PaperLevelView.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/view/PaperLevelView.java
@@ -217,8 +217,8 @@ public class PaperLevelView implements LevelView {
         if (level.getDragonFight() != null) {
             level.serverLevelData.setEndDragonFightData(level.getDragonFight().saveData());
         }
-        var save = level.getChunkSource().getDataStorage().scheduleSave();
-        if (!async) save.join();
+        /*var save =*/ level.getChunkSource().getDataStorage().save(async);
+        //if (!async) save.join();
 
         level.serverLevelData.setWorldBorder(level.getWorldBorder().createSettings());
         level.serverLevelData.setCustomBossEvents(level.getServer().getCustomBossEvents().save(level.registryAccess()));


### PR DESCRIPTION
This commit adds support for Folia by integrating a new FoliaLevel class and necessary configuration changes. It refactors the world creation process to accommodate Folia features and ensures compatibility with Paper environments. Additionally, minor tweaks and dependency changes were made to support these changes efficiently.