### PR TITLE
Handle NoClassDefFoundError in generator verification methods

### DIFF
--- a/src/main/java/net/thenextlvl/worlds/view/PluginGeneratorView.java
+++ b/src/main/java/net/thenextlvl/worlds/view/PluginGeneratorView.java
@@ -15,7 +15,7 @@ public class PluginGeneratorView implements GeneratorView {
     public boolean hasChunkGenerator(Class<? extends Plugin> clazz) {
         try {
             return clazz.getMethod("getDefaultWorldGenerator", String.class, String.class).getDeclaringClass().equals(clazz);
-        } catch (NoSuchMethodException e) {
+        } catch (NoClassDefFoundError | NoSuchMethodException e) {
             return false;
         }
     }
@@ -24,7 +24,7 @@ public class PluginGeneratorView implements GeneratorView {
     public boolean hasBiomeProvider(Class<? extends Plugin> clazz) {
         try {
             return clazz.getMethod("getDefaultBiomeProvider", String.class, String.class).getDeclaringClass().equals(clazz);
-        } catch (NoSuchMethodException e) {
+        } catch (NoClassDefFoundError | NoSuchMethodException e) {
             return false;
         }
     }


### PR DESCRIPTION
closes #84 

Updated the exception handling in `hasChunkGenerator` and `hasBiomeProvider` methods to also catch `NoClassDefFoundError`. This ensures more robust checks when verifying plugin methods and prevents potential runtime errors.