### PR TITLE
Avoid server softlock by replacing async teleport with sync

### DIFF
--- a/src/main/java/net/thenextlvl/worlds/command/WorldDeleteCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldDeleteCommand.java
@@ -68,7 +68,7 @@ class WorldDeleteCommand {
             return "world.delete.disallowed";
 
         var fallback = plugin.getServer().getWorlds().getFirst().getSpawnLocation();
-        world.getPlayers().forEach(player -> player.teleportAsync(fallback).join());
+        world.getPlayers().forEach(player -> player.teleport(fallback));
 
         if (!plugin.levelView().unloadLevel(world, false))
             return "world.unload.failed";

--- a/src/main/java/net/thenextlvl/worlds/command/WorldRegenerateCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldRegenerateCommand.java
@@ -74,7 +74,7 @@ class WorldRegenerateCommand {
         var players = world.getPlayers();
 
         var fallback = plugin.getServer().getWorlds().getFirst().getSpawnLocation();
-        players.forEach(player -> player.teleportAsync(fallback, COMMAND).join());
+        players.forEach(player -> player.teleport(fallback, COMMAND));
 
         plugin.levelView().saveLevelData(world, false);
 

--- a/src/main/java/net/thenextlvl/worlds/command/WorldUnloadCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldUnloadCommand.java
@@ -54,7 +54,7 @@ class WorldUnloadCommand {
 
         var fallbackSpawn = fallback != null ? fallback.getSpawnLocation()
                 : plugin.getServer().getWorlds().getFirst().getSpawnLocation();
-        world.getPlayers().forEach(player -> player.teleportAsync(fallbackSpawn).join());
+        world.getPlayers().forEach(player -> player.teleport(fallbackSpawn));
 
         plugin.persistStatus(world, false, false);
 


### PR DESCRIPTION
Replaced `teleportAsync` with `teleport` in world management commands to prevent server softlocks caused by joining async teleports. Ensures smoother player teleportation when unloading, deleting, or regenerating worlds.