### PR TITLE
Refactored group loading error handling

### DIFF
--- a/per-worlds/src/main/java/net/thenextlvl/perworlds/group/PaperGroupProvider.java
+++ b/per-worlds/src/main/java/net/thenextlvl/perworlds/group/PaperGroupProvider.java
@@ -1,6 +1,7 @@
 package net.thenextlvl.perworlds.group;
 
 import com.google.common.base.Preconditions;
+import core.i18n.file.ComponentBundle;
 import core.nbt.serialization.NBT;
 import core.nbt.serialization.adapter.EnumAdapter;
 import net.kyori.adventure.key.Key;
@@ -119,6 +120,10 @@ public class PaperGroupProvider implements GroupProvider {
 
     public NBT nbt() {
         return nbt;
+    }
+
+    public ComponentBundle bundle() {
+        return commons.bundle();
     }
 
     @Override

--- a/per-worlds/src/main/java/net/thenextlvl/perworlds/group/PaperWorldGroup.java
+++ b/per-worlds/src/main/java/net/thenextlvl/perworlds/group/PaperWorldGroup.java
@@ -4,8 +4,6 @@ import core.io.IO;
 import core.nbt.NBTInputStream;
 import core.nbt.NBTOutputStream;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import net.thenextlvl.perworlds.GroupData;
 import net.thenextlvl.perworlds.GroupSettings;
 import net.thenextlvl.perworlds.WorldGroup;
@@ -304,7 +302,7 @@ public class PaperWorldGroup implements WorldGroup {
                 .exceptionally(throwable -> {
                     provider.getLogger().error("Failed to load group data for player {}", player.getName(), throwable);
                     provider.getLogger().error("Please look for similar issues or report this on GitHub: {}", ISSUES);
-                    player.kick(Component.text("Failed to load group data", NamedTextColor.RED));
+                    player.kick(provider.bundle().component("group.load.failed", player));
                     return false;
                 });
     }

--- a/per-worlds/src/main/resources/per-worlds.properties
+++ b/per-worlds/src/main/resources/per-worlds.properties
@@ -6,6 +6,7 @@ group.exists=<red><prefix> A group named <dark_red><name></dark_red> already exi
 group.info=<gray><prefix> Group <green><group></green> contains <green><amount></green> <single:'world':'worlds'> <green><worlds:'<gray>, </gray>':'<gray> and </gray>'></green></gray>
 group.list.component=<hover:show_text:'<gray>Click to see more information</gray>'><click:run_command:'/world group info <group>'><group></click></hover>
 group.list=<gray><prefix> Groups <dark_gray>(<green><amount></green>):<dark_gray> <green><groups:'<gray>, </gray>'></green></gray>
+group.load.failed=<red>Failed to load group data<newline>Please report this issue to a server administrator</red>
 group.option.set=<gray><prefix> Set option <green><option></green> for group <green><group></green> to <green><value:'enabled':'disabled'></green></gray>
 group.option=<gray><prefix> Option <green><option></green> for group <green><group></green> is <green><value:'enabled':'disabled'></green></gray>
 group.spawn.set=<gray><prefix> Set group spawn for <green><group></green> at <green><world>, <x:0.###>, <y:0.###>, <z:0.###></green> [<green><yaw:0.###>, <pitch:0.###></green>]</gray>

--- a/per-worlds/src/main/resources/per-worlds_german.properties
+++ b/per-worlds/src/main/resources/per-worlds_german.properties
@@ -6,6 +6,7 @@ group.exists=<red><prefix> Eine Gruppe mit dem namen <dark_red><name></dark_red>
 group.info=<gray><prefix> Die Gruppe <green><group></green> hat <green><single:'eine':'<amount>'></green> <single:'Welt':'Welten'> <green><worlds:'<gray>, </gray>':'<gray> und </gray>'></green></gray>
 group.list.component=<hover:show_text:'<gray>Klicke, um mehr Information zu erhalten</gray>'><click:run_command:'/world group info <group>'><group></click></hover>
 group.list=<gray><prefix> Gruppen <dark_gray>(<green><amount></green>):<dark_gray> <green><groups:'<gray>, </gray>'></green></gray>
+group.load.failed=<red>Deine Daten konnten nicht geladen werden<newline>Bitte melde dieses Problem einem Serveradmin</red>
 group.option.set=<gray><prefix> Option <green><option></green> für Gruppe <green><group></green> ist jetzt <green><value:'aktiviert':'deaktiviert'></green></gray>
 group.option=<gray><prefix> Option <green><option></green> für Gruppe <green><group></green> ist <green><value:'aktiviert':'deaktiviert'></green></gray>
 group.spawn.set=<gray><prefix> Der Gruppeneinstiegspunk ist jetzt bei <green><group></green> at <green><world>, <x>, <y>, <z></green> [<green><yaw>, <pitch></green>]</gray>


### PR DESCRIPTION
Replaced static error message with localized bundle-based messages. Added `group.load.failed` to resource files for improved i18n support.