### PR TITLE
Use server default game mode in PaperGroupData

### DIFF
--- a/per-worlds/src/main/java/net/thenextlvl/perworlds/group/PaperGroupData.java
+++ b/per-worlds/src/main/java/net/thenextlvl/perworlds/group/PaperGroupData.java
@@ -31,9 +31,7 @@ public class PaperGroupData implements GroupData {
     private long time = 0;
 
     public PaperGroupData(Server server) {
-        // waiting on https://github.com/PaperMC/Paper/pull/12491
-        // this.defaultGameMode = server.getDefaultGameMode(); // todo: load after overworld? throws npe
-        this.defaultGameMode = GameMode.SURVIVAL;
+        this.defaultGameMode = server.getDefaultGameMode();
         this.hardcore = server.isHardcore();
     }
 


### PR DESCRIPTION
Removed hardcoded `GameMode.SURVIVAL` in favor of `server.getDefaultGameMode()` to align with server configuration.