### PR TITLE
Updated dependencies to support Paper 1.21.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-gameVersions=1.21.4
+gameVersions=1.21.4,1.21.5

--- a/per-worlds-api/build.gradle.kts
+++ b/per-worlds-api/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
     api("net.thenextlvl.core:nbt:2.3.2")
 }
 

--- a/per-worlds/build.gradle.kts
+++ b/per-worlds/build.gradle.kts
@@ -29,13 +29,13 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
 
     api("org.bstats:bstats-bukkit:3.1.0")
 
     api("net.thenextlvl.core:adapters:2.0.2")
     api("net.thenextlvl.core:i18n:3.2.0")
-    api("net.thenextlvl.core:paper:2.1.1")
+    api("net.thenextlvl.core:paper:2.1.2")
 
     api(project(":per-worlds-api"))
 

--- a/source-generator/build.gradle.kts
+++ b/source-generator/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    implementation("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
     implementation("com.palantir.javapoet:javapoet:0.7.0")
     implementation(project(":per-worlds-api"))
 

--- a/worlds-api/build.gradle.kts
+++ b/worlds-api/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
 
     compileOnlyApi(project(":per-worlds-api"))
     api("net.thenextlvl.core:adapters:2.0.2")

--- a/worlds/build.gradle.kts
+++ b/worlds/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     implementation(project(":worlds-api"))
     implementation(project(":per-worlds"))
     implementation("net.thenextlvl.core:i18n:3.2.0")
-    implementation("net.thenextlvl.core:paper:2.1.1")
+    implementation("net.thenextlvl.core:paper:2.1.2")
 }
 
 tasks.shadowJar {


### PR DESCRIPTION
Upgraded `paper-api` and related libraries to ensure compatibility with the latest Paper 1.21.5 release.