### PR TITLE
Add `bonusChest` support to levels

### DIFF
--- a/worlds-api/src/main/java/net/thenextlvl/worlds/api/model/Level.java
+++ b/worlds-api/src/main/java/net/thenextlvl/worlds/api/model/Level.java
@@ -39,5 +39,7 @@ public interface Level extends Keyed {
 
     boolean structures();
 
+    boolean bonusChest();
+
     long seed();
 }

--- a/worlds-api/src/main/java/net/thenextlvl/worlds/api/model/LevelBuilder.java
+++ b/worlds-api/src/main/java/net/thenextlvl/worlds/api/model/LevelBuilder.java
@@ -17,6 +17,9 @@ public interface LevelBuilder {
     Boolean structures();
 
     @Nullable
+    Boolean bonusChest();
+
+    @Nullable
     Generator generator();
 
     @Nullable
@@ -53,6 +56,8 @@ public interface LevelBuilder {
     LevelBuilder seed(@Nullable Long seed);
 
     LevelBuilder structures(@Nullable Boolean structures);
+
+    LevelBuilder bonusChest(@Nullable Boolean bonusChest);
 
     LevelBuilder type(@Nullable WorldPreset type);
 

--- a/worlds/src/main/java/net/thenextlvl/worlds/model/PaperLevel.java
+++ b/worlds/src/main/java/net/thenextlvl/worlds/model/PaperLevel.java
@@ -39,6 +39,7 @@ public class PaperLevel implements Level {
     protected final boolean hardcore;
     protected final boolean importedBefore;
     protected final boolean structures;
+    protected final boolean bonusChest;
     protected final long seed;
 
     public PaperLevel(WorldsPlugin plugin, LevelBuilder builder) {
@@ -85,6 +86,10 @@ public class PaperLevel implements Level {
                 .or(() -> settings.flatMap(tag -> tag.<ByteTag>optional("generate_features"))
                         .map(ByteTag::getAsBoolean))
                 .orElse(plugin.getServer().getGenerateStructures());
+        this.bonusChest = Optional.ofNullable(builder.bonusChest())
+                .or(() -> settings.flatMap(tag -> tag.<ByteTag>optional("bonus_chest"))
+                        .map(ByteTag::getAsBoolean))
+                .orElse(false);
 
 
         var worldPreset = generator.flatMap(plugin.levelView()::getWorldPreset);
@@ -135,6 +140,7 @@ public class PaperLevel implements Level {
                 .generatorSettings(generatorSettings)
                 .hardcore(hardcore)
                 .seed(seed)
+                .bonusChest(bonusChest)
                 .type(typeOf(type));
 
         if (generator != null) creator.generator(generator.generator(creator.name()));
@@ -180,6 +186,11 @@ public class PaperLevel implements Level {
     @Override
     public boolean structures() {
         return structures;
+    }
+
+    @Override
+    public boolean bonusChest() {
+        return bonusChest;
     }
 
     @Override

--- a/worlds/src/main/java/net/thenextlvl/worlds/model/PaperLevelBuilder.java
+++ b/worlds/src/main/java/net/thenextlvl/worlds/model/PaperLevelBuilder.java
@@ -20,6 +20,7 @@ public class PaperLevelBuilder implements LevelBuilder {
 
     private @Nullable Boolean hardcore;
     private @Nullable Boolean structures;
+    private @Nullable Boolean bonusChest;
     private @Nullable Generator generator;
     private @Nullable Long seed;
     private @Nullable NamespacedKey key;
@@ -41,6 +42,11 @@ public class PaperLevelBuilder implements LevelBuilder {
     @Override
     public @Nullable Boolean structures() {
         return structures;
+    }
+
+    @Override
+    public @Nullable Boolean bonusChest() {
+        return bonusChest;
     }
 
     @Override
@@ -128,6 +134,12 @@ public class PaperLevelBuilder implements LevelBuilder {
     @Override
     public LevelBuilder structures(@Nullable Boolean structures) {
         this.structures = structures;
+        return this;
+    }
+
+    @Override
+    public LevelBuilder bonusChest(@Nullable Boolean bonusChest) {
+        this.bonusChest = bonusChest;
         return this;
     }
 


### PR DESCRIPTION
Introduced `bonusChest` property to `Level` and `LevelBuilder` classes, allowing for configuration and retrieval of bonus chest settings. Updated related models and builders accordingly.