### PR TITLE
Fix `NoClassDefFoundError` for non-Folia servers

### DIFF
--- a/worlds/src/main/java/net/thenextlvl/worlds/level/PaperLevel.java
+++ b/worlds/src/main/java/net/thenextlvl/worlds/level/PaperLevel.java
@@ -238,7 +238,9 @@ class PaperLevel extends LevelData {
         serverLevel.setSpawnSettings(true);
 
         console.prepareLevels(serverLevel.getChunkSource().chunkMap.progressListener, serverLevel);
-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addWorld(serverLevel);
+        // fix noclassdeffound error if not running folia
+        if (WorldsPlugin.RUNNING_FOLIA)
+            io.papermc.paper.threadedregions.RegionizedServer.getInstance().addWorld(serverLevel);
         FeatureHooks.tickEntityManager(serverLevel);
 
         new WorldLoadEvent(serverLevel.getWorld()).callEvent();


### PR DESCRIPTION
Added conditional logic to `PaperLevel` to prevent calls to `RegionizedServer.addWorld` when not running on Folia. Ensures compatibility between Folia and non-Folia environments.