### PR TITLE
Added /seed command override

### DIFF
--- a/worlds/build.gradle.kts
+++ b/worlds/build.gradle.kts
@@ -90,6 +90,7 @@ paper {
                 "worlds.command.save-all",
                 "worlds.command.save-off",
                 "worlds.command.save-on",
+                "worlds.command.seed",
                 "worlds.command.setspawn",
                 "worlds.command.spawn",
                 "worlds.command.teleport",
@@ -135,6 +136,7 @@ paper {
         register("worlds.command.save-all") { children = listOf("worlds.command") }
         register("worlds.command.save-off") { children = listOf("worlds.command") }
         register("worlds.command.save-on") { children = listOf("worlds.command") }
+        register("worlds.command.seed") { children = listOf("minecraft.command.seed") }
         register("worlds.command.setspawn") { children = listOf("worlds.command") }
         register("worlds.command.spawn") { children = listOf("worlds.command") }
         register("worlds.command.teleport") { children = listOf("worlds.command") }

--- a/worlds/src/main/java/net/thenextlvl/worlds/WorldsPlugin.java
+++ b/worlds/src/main/java/net/thenextlvl/worlds/WorldsPlugin.java
@@ -10,6 +10,7 @@ import net.thenextlvl.worlds.api.WorldsProvider;
 import net.thenextlvl.worlds.api.generator.LevelStem;
 import net.thenextlvl.worlds.api.level.Level;
 import net.thenextlvl.worlds.api.view.GeneratorView;
+import net.thenextlvl.worlds.command.SeedCommand;
 import net.thenextlvl.worlds.command.WorldCommand;
 import net.thenextlvl.worlds.level.LevelData;
 import net.thenextlvl.worlds.link.WorldLinkProvider;
@@ -180,7 +181,9 @@ public class WorldsPlugin extends JavaPlugin implements WorldsProvider {
     }
 
     private void registerCommands() {
-        getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS.newHandler(event ->
-                event.registrar().register(WorldCommand.create(this))));
+        getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS.newHandler(event -> {
+            event.registrar().register(WorldCommand.create(this));
+            event.registrar().register(SeedCommand.create(this));
+        }));
     }
 }

--- a/worlds/src/main/java/net/thenextlvl/worlds/command/SeedCommand.java
+++ b/worlds/src/main/java/net/thenextlvl/worlds/command/SeedCommand.java
@@ -1,0 +1,32 @@
+package net.thenextlvl.worlds.command;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.thenextlvl.worlds.WorldsPlugin;
+import org.bukkit.World;
+import org.jspecify.annotations.NullMarked;
+
+import static net.thenextlvl.worlds.command.WorldCommand.worldArgument;
+
+@NullMarked
+public class SeedCommand {
+    public static LiteralCommandNode<CommandSourceStack> create(WorldsPlugin plugin) {
+        return Commands.literal("seed")
+                .requires(source -> source.getSender().hasPermission("minecraft.command.seed"))
+                .executes(context -> seed(context, context.getSource().getLocation().getWorld(), plugin))
+                .then(worldArgument(plugin).executes(context -> {
+                    var world = context.getArgument("world", World.class);
+                    return seed(context, world, plugin);
+                })).build();
+    }
+
+    private static int seed(CommandContext<CommandSourceStack> context, World world, WorldsPlugin plugin) {
+        plugin.bundle().sendMessage(context.getSource().getSender(), "world.info.seed",
+                Placeholder.parsed("seed", String.valueOf(world.getSeed())));
+        return Command.SINGLE_SUCCESS;
+    }
+}


### PR DESCRIPTION
Override the `seed` command to allow users to retrieve the seed of the current or specified world.