### PR TITLE
Fix NPE when upgrading world

### DIFF
--- a/per-worlds/src/main/java/net/thenextlvl/perworlds/group/PaperGroupData.java
+++ b/per-worlds/src/main/java/net/thenextlvl/perworlds/group/PaperGroupData.java
@@ -47,7 +47,9 @@ public class PaperGroupData implements GroupData {
 
     @Override
     public <T> Optional<T> getGameRule(GameRule<T> rule) {
-        return Optional.of(rule.getType().cast(gameRules.get(rule)));
+        var object = gameRules.get(rule);
+        if (object == null) return Optional.empty();
+        return Optional.of(rule.getType().cast(object));
     }
 
     @Override


### PR DESCRIPTION
Fixed a bug that threw a NullPointerException when encountering a gamerule that wasn't known before, typically on world upgrade