### PR TITLE
Handle unknown advancements during deserialization

### DIFF
--- a/per-worlds/src/main/java/net/thenextlvl/perworlds/adapter/AdvancementDataAdapter.java
+++ b/per-worlds/src/main/java/net/thenextlvl/perworlds/adapter/AdvancementDataAdapter.java
@@ -32,7 +32,9 @@ public class AdvancementDataAdapter implements TagAdapter<PaperAdvancementData> 
         server.advancementIterator().forEachRemaining(advancement -> lookup.put(advancement.key(), advancement));
 
         var root = tag.getAsCompound();
-        var advancement = lookup.get(context.deserialize(root.get("advancement"), Key.class));
+        var key = context.deserialize(root.get("advancement"), Key.class);
+        var advancement = lookup.get(key);
+        if (advancement == null) throw new ParserException("Encountered unknown advancement: " + key);
         var awarded = new HashMap<String, Date>();
         root.getAsCompound("awarded").forEach((criteria, date) -> awarded.put(criteria, context.deserialize(date, Date.class)));
         var remaining = root.getAsList("remaining").stream().map(Tag::getAsString).collect(Collectors.toSet());

--- a/per-worlds/src/main/java/net/thenextlvl/perworlds/group/PaperGroupProvider.java
+++ b/per-worlds/src/main/java/net/thenextlvl/perworlds/group/PaperGroupProvider.java
@@ -89,7 +89,7 @@ public class PaperGroupProvider implements GroupProvider {
                 .registerTypeHierarchyAdapter(Key.class, new KeyAdapter())
                 .registerTypeHierarchyAdapter(Location.class, new LocationAdapter())
                 .registerTypeHierarchyAdapter(NamespacedKey.class, new NamespacedKeyAdapter())
-                .registerTypeHierarchyAdapter(PaperPlayerData.class, new PlayerDataAdapter())
+                .registerTypeHierarchyAdapter(PaperPlayerData.class, new PlayerDataAdapter(this))
                 .registerTypeHierarchyAdapter(PotionEffect.class, new PotionEffectAdapter())
                 .registerTypeHierarchyAdapter(PotionEffectType.class, new PotionEffectTypeAdapter())
                 .registerTypeHierarchyAdapter(Stats.class, new StatisticsAdapter())


### PR DESCRIPTION
Throw a `ParserException` for unrecognized advancements to prevent upgrade errors.