### PR TITLE
Enforced range constraints for player data

### DIFF
--- a/per-worlds-api/src/main/java/net/thenextlvl/perworlds/data/PlayerData.java
+++ b/per-worlds-api/src/main/java/net/thenextlvl/perworlds/data/PlayerData.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Range;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.Nullable;
 
@@ -83,7 +84,7 @@ public interface PlayerData {
 
     PlayerData fireTicks(int fireTicks);
 
-    PlayerData flySpeed(float speed);
+    PlayerData flySpeed(@Range(from = -1, to = 1) float speed);
 
     PlayerData flying(TriState flying);
 
@@ -135,7 +136,7 @@ public interface PlayerData {
 
     PlayerData visualFire(TriState visualFire);
 
-    PlayerData walkSpeed(float speed);
+    PlayerData walkSpeed(@Range(from = -1, to = 1) float speed);
 
     PlayerData wardenSpawnTracker(WardenSpawnTracker tracker);
 

--- a/per-worlds/src/main/java/net/thenextlvl/perworlds/model/PaperPlayerData.java
+++ b/per-worlds/src/main/java/net/thenextlvl/perworlds/model/PaperPlayerData.java
@@ -1,5 +1,6 @@
 package net.thenextlvl.perworlds.model;
 
+import com.google.common.base.Preconditions;
 import net.kyori.adventure.util.TriState;
 import net.thenextlvl.perworlds.GroupSettings;
 import net.thenextlvl.perworlds.WorldGroup;
@@ -12,11 +13,13 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Range;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -192,6 +195,8 @@ public class PaperPlayerData implements PlayerData {
         player.setFlying((settings.flyState() ? flying : DEFAULT_FLYING)
                 .toBooleanOrElseGet(() -> player.getGameMode().equals(GameMode.SPECTATOR)));
 
+        applyAttributes(player, settings);
+
         player.setGliding(settings.gliding() ? gliding : DEFAULT_GLIDING);
 
         player.setPortalCooldown(settings.portalCooldown() ? portalCooldown : DEFAULT_PORTAL_COOLDOWN);
@@ -210,7 +215,10 @@ public class PaperPlayerData implements PlayerData {
         player.setLevel(settings.experience() ? level : DEFAULT_LEVEL);
 
         player.setInvulnerable(settings.invulnerable() ? invulnerable : DEFAULT_INVULNERABLE);
-        player.setHealth(settings.health() ? health : DEFAULT_HEALTH);
+
+        var attribute = player.getAttribute(Attribute.MAX_HEALTH);
+        var maxHealth = attribute != null ? attribute.getValue() : 20;
+        player.setHealth(Math.clamp(settings.health() ? health : DEFAULT_HEALTH, 0, maxHealth));
 
         player.setAbsorptionAmount(settings.absorption() ? absorption : DEFAULT_ABSORPTION);
         player.setExhaustion(settings.exhaustion() ? exhaustion : DEFAULT_EXHAUSTION);
@@ -227,8 +235,8 @@ public class PaperPlayerData implements PlayerData {
         player.setLastDeathLocation(settings.lastDeathLocation() ? lastDeathLocation : DEFAULT_LAST_DEATH_LOCATION);
         player.setRespawnLocation(settings.respawnLocation() ? respawnLocation : DEFAULT_RESPAWN_LOCATION, false);
 
-        player.setFlySpeed(settings.flySpeed() ? flySpeed : DEFAULT_FLY_SPEED);
-        player.setWalkSpeed(settings.walkSpeed() ? walkSpeed : DEFAULT_WALK_SPEED);
+        player.setFlySpeed(Math.clamp(settings.flySpeed() ? flySpeed : DEFAULT_FLY_SPEED, -1, 1));
+        player.setWalkSpeed(Math.clamp(settings.walkSpeed() ? walkSpeed : DEFAULT_WALK_SPEED, -1, 1));
 
         player.clearActivePotionEffects();
         if (settings.potionEffects()) player.addPotionEffects(potionEffects);
@@ -243,7 +251,6 @@ public class PaperPlayerData implements PlayerData {
 
         updateTablistVisibility(player, group);
 
-        applyAttributes(player, settings);
         applyAdvancements(player, settings);
         applyRecipes(player, settings);
     }
@@ -410,7 +417,8 @@ public class PaperPlayerData implements PlayerData {
     }
 
     @Override
-    public PaperPlayerData flySpeed(float speed) {
+    public PaperPlayerData flySpeed(@Range(from = -1, to = 1) float speed) {
+        Preconditions.checkArgument(speed >= -1 && speed <= 1, "Speed must be between -1 and 1");
         this.flySpeed = speed;
         return this;
     }
@@ -447,6 +455,7 @@ public class PaperPlayerData implements PlayerData {
 
     @Override
     public PaperPlayerData health(double health) {
+        Preconditions.checkArgument(health >= 0, "Health must be greater than or equal to 0");
         this.health = health;
         return this;
     }
@@ -506,7 +515,8 @@ public class PaperPlayerData implements PlayerData {
     }
 
     @Override
-    public PaperPlayerData walkSpeed(float speed) {
+    public PaperPlayerData walkSpeed(@Range(from = -1, to = 1) float speed) {
+        Preconditions.checkArgument(speed >= -1 && speed <= 1, "Speed must be between -1 and 1");
         this.walkSpeed = speed;
         return this;
     }


### PR DESCRIPTION
Added `@Range` annotations and `Preconditions` for validating inputs of fly speed, walk speed, and health, ensuring they remain within defined boundaries to prevent invalid assignments. Clamped values to their respective min and max to prevent runtime errors.