### PR TITLE
Api improvements

### DIFF
--- a/api/src/main/java/net/thenextlvl/worlds/api/WorldsProvider.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/WorldsProvider.java
@@ -8,6 +8,7 @@ import net.thenextlvl.worlds.api.view.LevelView;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -28,6 +29,7 @@ public interface WorldsProvider extends Plugin {
      *
      * @return the {@link GeneratorView} instance used for managing and retrieving generator information
      */
+    @Contract(pure = true)
     GeneratorView generatorView();
 
     /**
@@ -37,6 +39,7 @@ public interface WorldsProvider extends Plugin {
      * @param level the path representing the level to be built
      * @return a {@link Level.Builder} for configuring and creating the specified level
      */
+    @Contract(value = "_ -> new", pure = true)
     Level.Builder levelBuilder(Path level);
 
     /**
@@ -46,6 +49,7 @@ public interface WorldsProvider extends Plugin {
      * @param world the world to create a builder copy from
      * @return a {@link Level.Builder} instance for configuring and modifying the copied level
      */
+    @Contract(value = "_ -> new", pure = true)
     Level.Builder levelBuilder(World world);
 
     /**
@@ -54,6 +58,7 @@ public interface WorldsProvider extends Plugin {
      *
      * @return the {@link LevelView} instance used to interact with world level operations
      */
+    @Contract(pure = true)
     LevelView levelView();
 
     /**
@@ -64,6 +69,7 @@ public interface WorldsProvider extends Plugin {
      *
      * @return the {@link LinkProvider} instance
      */
+    @Contract(pure = true)
     LinkProvider linkProvider();
 
     /**
@@ -73,6 +79,7 @@ public interface WorldsProvider extends Plugin {
      * @return the {@link net.thenextlvl.perworlds.GroupProvider} instance, or {@code null} if unsupported (e.g., in environments like Folia)
      * @deprecated Worlds does no longer provide PerWorlds anymore.
      */
+    @Contract(pure = true)
     @Deprecated(forRemoval = true, since = "3.3.0")
     default net.thenextlvl.perworlds.@Nullable GroupProvider groupProvider() {
         return org.bukkit.Bukkit.getServicesManager().load(net.thenextlvl.perworlds.GroupProvider.class);

--- a/api/src/main/java/net/thenextlvl/worlds/api/WorldsProvider.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/WorldsProvider.java
@@ -19,6 +19,8 @@ import java.nio.file.Path;
  * functionalities such as chunk generation, level handling, and world grouping.
  * It provides access to various tools and services
  * that facilitate operations on Minecraft world data and configurations.
+ *
+ * @since 2.0.0
  */
 @NullMarked
 public interface WorldsProvider extends Plugin {
@@ -38,6 +40,7 @@ public interface WorldsProvider extends Plugin {
      *
      * @param level the path representing the level to be built
      * @return a {@link Level.Builder} for configuring and creating the specified level
+     * @since 3.0.0
      */
     @Contract(value = "_ -> new", pure = true)
     Level.Builder levelBuilder(Path level);
@@ -48,6 +51,7 @@ public interface WorldsProvider extends Plugin {
      *
      * @param world the world to create a builder copy from
      * @return a {@link Level.Builder} instance for configuring and modifying the copied level
+     * @since 3.0.0
      */
     @Contract(value = "_ -> new", pure = true)
     Level.Builder levelBuilder(World world);
@@ -68,6 +72,7 @@ public interface WorldsProvider extends Plugin {
      * and management of links between worlds and their portal relationships.
      *
      * @return the {@link LinkProvider} instance
+     * @since 3.0.0
      */
     @Contract(pure = true)
     LinkProvider linkProvider();
@@ -77,6 +82,7 @@ public interface WorldsProvider extends Plugin {
      * A group provider facilitates the creation, retrieval, and modification of world groups.
      *
      * @return the {@link net.thenextlvl.perworlds.GroupProvider} instance, or {@code null} if unsupported (e.g., in environments like Folia)
+     * @since 2.2.0
      * @deprecated Worlds does no longer provide PerWorlds anymore.
      */
     @Contract(pure = true)

--- a/api/src/main/java/net/thenextlvl/worlds/api/event/WorldActionScheduledEvent.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/event/WorldActionScheduledEvent.java
@@ -22,6 +22,8 @@ import java.util.function.Consumer;
  * <p>
  * The {@link ActionType} enum defines the possible actions that can be scheduled,
  * such as deleting a world or regenerating it.
+ *
+ * @since 3.0.0
  */
 @NullMarked
 public class WorldActionScheduledEvent extends WorldEvent implements Cancellable {

--- a/api/src/main/java/net/thenextlvl/worlds/api/event/WorldActionScheduledEvent.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/event/WorldActionScheduledEvent.java
@@ -5,6 +5,7 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.world.WorldEvent;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -41,6 +42,7 @@ public class WorldActionScheduledEvent extends WorldEvent implements Cancellable
      *
      * @return the scheduled action type
      */
+    @Contract(pure = true)
     public ActionType getActionType() {
         return actionType;
     }
@@ -50,6 +52,7 @@ public class WorldActionScheduledEvent extends WorldEvent implements Cancellable
      *
      * @param action the action to be performed
      */
+    @Contract(mutates = "this")
     public void addAction(Consumer<Path> action) {
         this.action = this.action != null ? this.action.andThen(action) : action;
     }
@@ -60,11 +63,13 @@ public class WorldActionScheduledEvent extends WorldEvent implements Cancellable
     }
 
     @Override
+    @Contract(pure = true)
     public boolean isCancelled() {
         return this.cancelled;
     }
 
     @Override
+    @Contract(mutates = "this")
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
     }

--- a/api/src/main/java/net/thenextlvl/worlds/api/event/WorldBackupEvent.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/event/WorldBackupEvent.java
@@ -9,6 +9,8 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Represents an event triggered when a {@link World} is backed up.
  * This event allows developers to modify the world before it is written to disk.
+ *
+ * @since 3.0.0
  */
 @NullMarked
 public class WorldBackupEvent extends WorldEvent {

--- a/api/src/main/java/net/thenextlvl/worlds/api/event/WorldCloneEvent.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/event/WorldCloneEvent.java
@@ -20,6 +20,8 @@ import java.util.function.BiPredicate;
  * It provides information about whether the entire
  * world, including all data and entities, is being cloned, or if only the
  * {@code level.dat} is copied for generation.
+ *
+ * @since 3.0.0
  */
 @NullMarked
 public class WorldCloneEvent extends WorldEvent {
@@ -41,7 +43,7 @@ public class WorldCloneEvent extends WorldEvent {
     public @Nullable BiPredicate<Path, BasicFileAttributes> getFileFilter() {
         return fileFilter;
     }
-    
+
     /**
      * Retrieves the cloned {@link Level} associated with this event.
      *

--- a/api/src/main/java/net/thenextlvl/worlds/api/event/WorldCloneEvent.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/event/WorldCloneEvent.java
@@ -6,6 +6,7 @@ import org.bukkit.World;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.world.WorldEvent;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -36,6 +37,7 @@ public class WorldCloneEvent extends WorldEvent {
     }
 
     @ApiStatus.Internal
+    @Contract(pure = true)
     public @Nullable BiPredicate<Path, BasicFileAttributes> getFileFilter() {
         return fileFilter;
     }
@@ -45,6 +47,7 @@ public class WorldCloneEvent extends WorldEvent {
      *
      * @return the clone of the level involved in the cloning process
      */
+    @Contract(pure = true)
     public Level getClone() {
         return clone;
     }
@@ -66,6 +69,7 @@ public class WorldCloneEvent extends WorldEvent {
      *               {@code false} otherwise
      * @throws IllegalStateException if the event represents a non-{@link #isFullClone() full} clone operation
      */
+    @Contract(mutates = "this")
     public void addFileFilter(BiPredicate<Path, BasicFileAttributes> filter) throws IllegalStateException {
         Preconditions.checkState(full, "Cannot add file filter to non-full clone event");
         this.fileFilter = this.fileFilter != null ? this.fileFilter.and(filter) : filter;
@@ -77,6 +81,7 @@ public class WorldCloneEvent extends WorldEvent {
      *
      * @return true if the entire world will be cloned, false, if only the {@code level.dat} file will be cloned
      */
+    @Contract(pure = true)
     public boolean isFullClone() {
         return full;
     }

--- a/api/src/main/java/net/thenextlvl/worlds/api/event/WorldDeleteEvent.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/event/WorldDeleteEvent.java
@@ -14,6 +14,7 @@ import org.jspecify.annotations.NullMarked;
  * It also provides an option to check if the deleted world is slated for regeneration.
  *
  * @see WorldActionScheduledEvent
+ * @since 2.0.0
  */
 @NullMarked
 public class WorldDeleteEvent extends WorldEvent implements Cancellable {

--- a/api/src/main/java/net/thenextlvl/worlds/api/event/WorldDeleteEvent.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/event/WorldDeleteEvent.java
@@ -5,6 +5,7 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.world.WorldEvent;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -26,11 +27,13 @@ public class WorldDeleteEvent extends WorldEvent implements Cancellable {
     }
 
     @Override
+    @Contract(pure = true)
     public boolean isCancelled() {
         return this.cancelled;
     }
 
     @Override
+    @Contract(mutates = "this")
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
     }

--- a/api/src/main/java/net/thenextlvl/worlds/api/event/WorldRegenerateEvent.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/event/WorldRegenerateEvent.java
@@ -14,6 +14,7 @@ import org.jspecify.annotations.NullMarked;
  * providing an opportunity for developers to listen to or modify the regeneration process.
  *
  * @see WorldActionScheduledEvent
+ * @since 2.0.0
  */
 @NullMarked
 public class WorldRegenerateEvent extends WorldEvent implements Cancellable {

--- a/api/src/main/java/net/thenextlvl/worlds/api/event/WorldRegenerateEvent.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/event/WorldRegenerateEvent.java
@@ -5,6 +5,7 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.world.WorldEvent;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -26,11 +27,13 @@ public class WorldRegenerateEvent extends WorldEvent implements Cancellable {
     }
 
     @Override
+    @Contract(pure = true)
     public boolean isCancelled() {
         return this.cancelled;
     }
 
     @Override
+    @Contract(mutates = "this")
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
     }

--- a/api/src/main/java/net/thenextlvl/worlds/api/exception/GeneratorException.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/exception/GeneratorException.java
@@ -1,6 +1,7 @@
 package net.thenextlvl.worlds.api.exception;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -32,6 +33,7 @@ public class GeneratorException extends RuntimeException {
      *
      * @return a string representing the plugin name
      */
+    @Contract(pure = true)
     public String getPlugin() {
         return plugin;
     }
@@ -41,6 +43,7 @@ public class GeneratorException extends RuntimeException {
      *
      * @return a nullable string representing the ID of the generator, or null if no ID is provided
      */
+    @Contract(pure = true)
     public @Nullable String getId() {
         return id;
     }

--- a/api/src/main/java/net/thenextlvl/worlds/api/exception/GeneratorException.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/exception/GeneratorException.java
@@ -8,6 +8,8 @@ import org.jspecify.annotations.Nullable;
 /**
  * The GeneratorException class is a custom exception that is thrown when a requested plugin as a generator
  * cannot be found, is disabled, or doesn't provide a chunk generator or biome provider.
+ *
+ * @since 2.0.0
  */
 @NullMarked
 public class GeneratorException extends RuntimeException {
@@ -32,6 +34,7 @@ public class GeneratorException extends RuntimeException {
      * Retrieves the name of the plugin associated with the generator exception.
      *
      * @return a string representing the plugin name
+     * @since 2.0.4
      */
     @Contract(pure = true)
     public String getPlugin() {
@@ -42,6 +45,7 @@ public class GeneratorException extends RuntimeException {
      * Retrieves the unique identifier associated with the generator exception.
      *
      * @return a nullable string representing the ID of the generator, or null if no ID is provided
+     * @since 2.0.4
      */
     @Contract(pure = true)
     public @Nullable String getId() {

--- a/api/src/main/java/net/thenextlvl/worlds/api/generator/BiomeSource.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/generator/BiomeSource.java
@@ -9,6 +9,9 @@ import org.jspecify.annotations.NullMarked;
 
 import java.util.Set;
 
+/**
+ * @since 3.0.0
+ */
 @NullMarked
 @ApiStatus.Experimental
 public interface BiomeSource extends Keyed {

--- a/api/src/main/java/net/thenextlvl/worlds/api/generator/BiomeSource.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/generator/BiomeSource.java
@@ -3,6 +3,7 @@ package net.thenextlvl.worlds.api.generator;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 
@@ -19,6 +20,7 @@ public interface BiomeSource extends Keyed {
      * @param biomes the set of biomes to use for the checkerboard pattern
      * @return a new CheckerboardColumnBiomeSource configured with the specified biomes
      */
+    @Contract(value = "_ -> new", pure = true)
     static CheckerboardColumnBiomeSource checkerboard(Set<Key> biomes) {
         return new CheckerboardColumnBiomeSource(biomes);
     }
@@ -30,6 +32,7 @@ public interface BiomeSource extends Keyed {
      * @param biome the biome to use for the world
      * @return a new FixedBiomeSource configured with the specified biome
      */
+    @Contract(value = "_ -> new", pure = true)
     static FixedBiomeSource fixed(Key biome) {
         return new FixedBiomeSource(biome);
     }
@@ -58,11 +61,13 @@ public interface BiomeSource extends Keyed {
          *
          * @return the biome key
          */
+        @Contract(pure = true)
         public Key biome() {
             return biome;
         }
 
         @Override
+        @Contract(pure = true)
         public Key key() {
             return key;
         }
@@ -92,11 +97,13 @@ public interface BiomeSource extends Keyed {
          *
          * @return an unmodifiable set of biome keys
          */
+        @Contract(pure = true)
         public @Unmodifiable Set<Key> biomes() {
             return Set.copyOf(biomes);
         }
 
         @Override
+        @Contract(pure = true)
         public Key key() {
             return key;
         }

--- a/api/src/main/java/net/thenextlvl/worlds/api/generator/DimensionType.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/generator/DimensionType.java
@@ -4,6 +4,9 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * @since 3.0.0
+ */
 // https://minecraft.wiki/w/Dimension_type
 @ApiStatus.Experimental
 public record DimensionType(Key key) implements Keyed {

--- a/api/src/main/java/net/thenextlvl/worlds/api/generator/Generator.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/generator/Generator.java
@@ -5,6 +5,7 @@ import net.thenextlvl.worlds.api.exception.GeneratorException;
 import org.bukkit.generator.BiomeProvider;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -30,6 +31,7 @@ public record Generator(Plugin plugin, @Nullable String id) {
         return plugin().getDefaultBiomeProvider(worldName, id());
     }
 
+    @Contract(value = "_, _ -> new", pure = true)
     public static Generator of(WorldsProvider provider, String string) throws GeneratorException {
         var split = string.split(":", 2);
 

--- a/api/src/main/java/net/thenextlvl/worlds/api/generator/Generator.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/generator/Generator.java
@@ -16,6 +16,8 @@ import org.jspecify.annotations.Nullable;
  * <p>
  * The `Generator` record offers methods to serialize its state, retrieve chunk generators,
  * and obtain biome providers for specific world names.
+ *
+ * @since 3.0.0
  */
 @NullMarked
 public record Generator(Plugin plugin, @Nullable String id) {

--- a/api/src/main/java/net/thenextlvl/worlds/api/generator/GeneratorType.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/generator/GeneratorType.java
@@ -8,6 +8,9 @@ import org.jspecify.annotations.NullMarked;
 
 import java.util.Optional;
 
+/**
+ * @since 3.0.0
+ */
 @NullMarked
 @ApiStatus.Experimental
 public record GeneratorType(Key key) implements Keyed {

--- a/api/src/main/java/net/thenextlvl/worlds/api/generator/GeneratorType.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/generator/GeneratorType.java
@@ -47,6 +47,7 @@ public record GeneratorType(Key key) implements Keyed {
      */
     public static final GeneratorType SINGLE_BIOME = new GeneratorType(Key.key("minecraft", "fixed"));
 
+    @ApiStatus.Internal
     @Contract(pure = true)
     public Key presetName() {
         if (equals(DEBUG)) return Key.key("debug_all_block_states");

--- a/api/src/main/java/net/thenextlvl/worlds/api/generator/GeneratorType.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/generator/GeneratorType.java
@@ -3,6 +3,7 @@ package net.thenextlvl.worlds.api.generator;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Optional;
@@ -46,6 +47,7 @@ public record GeneratorType(Key key) implements Keyed {
      */
     public static final GeneratorType SINGLE_BIOME = new GeneratorType(Key.key("minecraft", "fixed"));
 
+    @Contract(pure = true)
     public Key presetName() {
         if (equals(DEBUG)) return Key.key("debug_all_block_states");
         if (equals(SINGLE_BIOME)) return Key.key("single_biome_surface");
@@ -53,6 +55,7 @@ public record GeneratorType(Key key) implements Keyed {
         return key();
     }
 
+    @Contract(pure = true)
     public static Optional<GeneratorType> getByKey(Key key) {
         if (key.equals(AMPLIFIED.key())) return Optional.of(AMPLIFIED);
         if (key.equals(DEBUG.key())) return Optional.of(DEBUG);

--- a/api/src/main/java/net/thenextlvl/worlds/api/generator/LevelStem.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/generator/LevelStem.java
@@ -2,6 +2,9 @@ package net.thenextlvl.worlds.api.generator;
 
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * @since 3.0.0
+ */
 @ApiStatus.Experimental
 public record LevelStem(DimensionType dimensionType) {
     public static final LevelStem OVERWORLD = new LevelStem(DimensionType.OVERWORLD);

--- a/api/src/main/java/net/thenextlvl/worlds/api/level/Level.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/level/Level.java
@@ -20,6 +20,9 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * @since 3.0.0
+ */
 @NullMarked
 public interface Level extends Keyed {
     /**
@@ -166,6 +169,7 @@ public interface Level extends Keyed {
      * </ul>
      *
      * @return a {@code CompletableFuture} completing with the created {@link World}
+     * @since 3.2.0
      */
     @Contract(mutates = "io")
     CompletableFuture<World> createAsync();

--- a/api/src/main/java/net/thenextlvl/worlds/api/level/Level.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/level/Level.java
@@ -102,8 +102,10 @@ public interface Level extends Keyed {
      * Retrieves the spawn chunk radius for the level.
      *
      * @return an integer representing the spawn chunk radius
+     * @deprecated spawn chunks will be removed in the next release of minecraft
      */
     @Contract(pure = true)
+    @Deprecated(forRemoval = true, since = "3.3.1")
     int getSpawnChunkRadius();
 
     /**
@@ -371,9 +373,11 @@ public interface Level extends Keyed {
          *
          * @return an {@link Integer} representing the radius of spawn chunks to keep loaded,
          * or null if the default value is to be used.
+         * @deprecated spawn chunks will be removed in the next release of minecraft
          */
         @Nullable
         @Contract(pure = true)
+        @Deprecated(forRemoval = true, since = "3.3.1")
         Integer spawnChunkRadius();
 
         /**
@@ -383,8 +387,10 @@ public interface Level extends Keyed {
          * @param radius an {@link Integer} representing the radius of chunks to keep loaded,
          *               or null to use the server default
          * @return the builder instance for chaining method calls
+         * @deprecated spawn chunks will be removed in the next release of minecraft
          */
         @Contract(mutates = "this")
+        @Deprecated(forRemoval = true, since = "3.3.1")
         Builder spawnChunkRadius(@Nullable Integer radius);
 
         /**

--- a/api/src/main/java/net/thenextlvl/worlds/api/level/Level.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/level/Level.java
@@ -12,6 +12,7 @@ import org.bukkit.World;
 import org.bukkit.generator.BiomeProvider;
 import org.bukkit.generator.ChunkGenerator;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -26,6 +27,7 @@ public interface Level extends Keyed {
      *
      * @return the file path as a {@code Path} object
      */
+    @Contract(pure = true)
     Path getDirectory();
 
     /**
@@ -33,6 +35,7 @@ public interface Level extends Keyed {
      *
      * @return the level name as a {@code String}
      */
+    @Contract(pure = true)
     String getName();
 
     /**
@@ -41,6 +44,7 @@ public interface Level extends Keyed {
      * @return an {@code Optional} containing the {@code Preset} if one is present, or {@link Optional#empty()}
      * if no preset is associated with the level
      */
+    @Contract(pure = true)
     Optional<Preset> getPreset();
 
     /**
@@ -49,6 +53,7 @@ public interface Level extends Keyed {
      * @return an {@code Optional} containing the {@code BiomeProvider} if one is present, or {@link Optional#empty()}
      * if no biome provider is associated with the level
      */
+    @Contract(pure = true)
     Optional<BiomeProvider> getBiomeProvider();
 
     /**
@@ -57,6 +62,7 @@ public interface Level extends Keyed {
      * @return an {@code Optional} containing the {@code ChunkGenerator} if one is present, or {@link Optional#empty()}
      * if no chunk generator is associated with the level
      */
+    @Contract(pure = true)
     Optional<ChunkGenerator> getChunkGenerator();
 
     /**
@@ -65,6 +71,7 @@ public interface Level extends Keyed {
      * @return an {@code Optional} containing the {@code Generator} if one is present, or {@link Optional#empty()}
      * if no generator is associated with the level
      */
+    @Contract(pure = true)
     Optional<Generator> getGenerator();
 
     /**
@@ -72,6 +79,7 @@ public interface Level extends Keyed {
      *
      * @return true if the level is set to hardcore mode, false otherwise
      */
+    @Contract(pure = true)
     boolean isHardcore();
 
     /**
@@ -79,6 +87,7 @@ public interface Level extends Keyed {
      *
      * @return true if structures are present in the level, false otherwise
      */
+    @Contract(pure = true)
     boolean hasStructures();
 
     /**
@@ -86,6 +95,7 @@ public interface Level extends Keyed {
      *
      * @return true if the bonus chest is enabled for this level, false otherwise
      */
+    @Contract(pure = true)
     boolean hasBonusChest();
 
     /**
@@ -93,6 +103,7 @@ public interface Level extends Keyed {
      *
      * @return an integer representing the spawn chunk radius
      */
+    @Contract(pure = true)
     int getSpawnChunkRadius();
 
     /**
@@ -100,18 +111,23 @@ public interface Level extends Keyed {
      *
      * @return the seed value as a {@code long}
      */
+    @Contract(pure = true)
     long getSeed();
 
+    @Contract(pure = true)
     @ApiStatus.Experimental
     GeneratorType getGeneratorType();
 
+    @Contract(pure = true)
     @ApiStatus.Experimental
     LevelStem getLevelStem();
 
     @ApiStatus.Internal
+    @Contract(pure = true)
     TriState isEnabled();
 
     @ApiStatus.Internal
+    @Contract(pure = true)
     boolean isWorldKnown();
 
     /**
@@ -120,6 +136,7 @@ public interface Level extends Keyed {
      *
      * @return a Builder instance initialized with the current Level's configuration
      */
+    @Contract(pure = true)
     Builder toBuilder();
 
     /**
@@ -130,6 +147,7 @@ public interface Level extends Keyed {
      * @return an {@code Optional} containing the created {@code World}, or {@link Optional#empty()} otherwise
      * @deprecated use {@link #createAsync()}
      */
+    @Contract(mutates = "io")
     @Deprecated(forRemoval = true, since = "3.2.0")
     default Optional<World> create() {
         return Optional.of(createAsync().join());
@@ -147,6 +165,7 @@ public interface Level extends Keyed {
      *
      * @return a {@code CompletableFuture} completing with the created {@link World}
      */
+    @Contract(mutates = "io")
     CompletableFuture<World> createAsync();
 
     interface Builder {
@@ -155,6 +174,7 @@ public interface Level extends Keyed {
          *
          * @return the {@link Path} representing the directory, or null if no directory is set
          */
+        @Contract(pure = true)
         Path directory();
 
         /**
@@ -163,6 +183,7 @@ public interface Level extends Keyed {
          * @param directory the {@link Path} representing the directory to set
          * @return the builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder directory(Path directory);
 
         /**
@@ -171,6 +192,7 @@ public interface Level extends Keyed {
          * @return the {@link Key} instance associated with the builder, or null if no key is set
          */
         @Nullable
+        @Contract(pure = true)
         Key key();
 
         /**
@@ -179,6 +201,7 @@ public interface Level extends Keyed {
          * @param key the {@link Key} instance to associate with the builder, or null to unset the key
          * @return the builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder key(@Nullable Key key);
 
         /**
@@ -187,6 +210,7 @@ public interface Level extends Keyed {
          * @return the name as a {@link String}, or null if no name is set
          */
         @Nullable
+        @Contract(pure = true)
         String name();
 
         /**
@@ -195,6 +219,7 @@ public interface Level extends Keyed {
          * @param name the name to associate with the builder, or null to unset the name
          * @return the builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder name(@Nullable String name);
 
         /**
@@ -205,6 +230,7 @@ public interface Level extends Keyed {
          * @return the {@link BiomeProvider} instance, or null if no biome provider is set
          */
         @Nullable
+        @Contract(pure = true)
         BiomeProvider biomeProvider();
 
         /**
@@ -214,6 +240,7 @@ public interface Level extends Keyed {
          * @param provider the {@link BiomeProvider} to set, or null to remove any previously set biome provider
          * @return the builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder biomeProvider(@Nullable BiomeProvider provider);
 
         /**
@@ -225,6 +252,7 @@ public interface Level extends Keyed {
          * or null if no chunk generator has been set.
          */
         @Nullable
+        @Contract(pure = true)
         ChunkGenerator chunkGenerator();
 
         /**
@@ -234,6 +262,7 @@ public interface Level extends Keyed {
          * @param generator the {@link ChunkGenerator} instance to set, or null to remove the chunk generator.
          * @return the builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder chunkGenerator(@Nullable ChunkGenerator generator);
 
         /**
@@ -243,6 +272,7 @@ public interface Level extends Keyed {
          * @return the {@link Generator} instance associated with the builder, or null if no generator is set
          */
         @Nullable
+        @Contract(pure = true)
         Generator generator();
 
         /**
@@ -251,6 +281,7 @@ public interface Level extends Keyed {
          * @param generator the {@link Generator} instance to set, or null to remove the generator configuration
          * @return the builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder generator(@Nullable Generator generator);
 
         /**
@@ -260,6 +291,7 @@ public interface Level extends Keyed {
          * @return the {@link Preset} applied to the builder, or null if no preset is set
          */
         @Nullable
+        @Contract(pure = true)
         Preset preset();
 
         /**
@@ -269,6 +301,7 @@ public interface Level extends Keyed {
          * @param preset the {@link Preset} to apply to the builder, or null to leave the preset undefined
          * @return the builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder preset(@Nullable Preset preset);
 
         /**
@@ -278,6 +311,7 @@ public interface Level extends Keyed {
          * or null if the value is not explicitly set and the server default should be used.
          */
         @Nullable
+        @Contract(pure = true)
         Boolean hardcore();
 
         /**
@@ -288,6 +322,7 @@ public interface Level extends Keyed {
          *                 or null to use the server default
          * @return the builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder hardcore(@Nullable Boolean hardcore);
 
         /**
@@ -297,6 +332,7 @@ public interface Level extends Keyed {
          * or null if the server default should be used
          */
         @Nullable
+        @Contract(pure = true)
         Boolean structures();
 
         /**
@@ -307,6 +343,7 @@ public interface Level extends Keyed {
          *                   be generated, or null to use the server default
          * @return the builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder structures(@Nullable Boolean structures);
 
         /**
@@ -315,6 +352,7 @@ public interface Level extends Keyed {
          * @return a {@link Boolean} indicating whether a bonus chest should be generated.
          */
         @Nullable
+        @Contract(pure = true)
         Boolean bonusChest();
 
         /**
@@ -325,6 +363,7 @@ public interface Level extends Keyed {
          *                   should be generated, or null to leave the value unset
          * @return the builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder bonusChest(@Nullable Boolean bonusChest);
 
         /**
@@ -334,6 +373,7 @@ public interface Level extends Keyed {
          * or null if the default value is to be used.
          */
         @Nullable
+        @Contract(pure = true)
         Integer spawnChunkRadius();
 
         /**
@@ -344,6 +384,7 @@ public interface Level extends Keyed {
          *               or null to use the server default
          * @return the builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder spawnChunkRadius(@Nullable Integer radius);
 
         /**
@@ -352,6 +393,7 @@ public interface Level extends Keyed {
          * @return the seed as a {@link Long}, or null if no seed is set
          */
         @Nullable
+        @Contract(pure = true)
         Long seed();
 
         /**
@@ -360,6 +402,7 @@ public interface Level extends Keyed {
          * @param seed the seed to use for world generation, or null to generate a random seed
          * @return this builder instance for chaining method calls
          */
+        @Contract(mutates = "this")
         Builder seed(@Nullable Long seed);
 
         /**
@@ -367,33 +410,42 @@ public interface Level extends Keyed {
          *
          * @return the constructed Level instance
          */
+        @Contract(pure = true)
         Level build();
 
         @Nullable
+        @Contract(pure = true)
         @ApiStatus.Experimental
         LevelStem levelStem();
 
         @ApiStatus.Experimental
+        @Contract(mutates = "this")
         Builder levelStem(@Nullable LevelStem type);
 
         @Nullable
+        @Contract(pure = true)
         @ApiStatus.Experimental
         GeneratorType generatorType();
 
         @ApiStatus.Experimental
+        @Contract(mutates = "this")
         Builder generatorType(@Nullable GeneratorType type);
 
         @Nullable
         @ApiStatus.Internal
+        @Contract(pure = true)
         Boolean worldKnown();
 
         @ApiStatus.Internal
+        @Contract(mutates = "this")
         Builder worldKnown(@Nullable Boolean worldKnown);
 
         @ApiStatus.Internal
+        @Contract(pure = true)
         TriState enabled();
 
         @ApiStatus.Internal
+        @Contract(mutates = "this")
         Builder enabled(TriState enabled);
     }
 }

--- a/api/src/main/java/net/thenextlvl/worlds/api/link/LinkProvider.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/link/LinkProvider.java
@@ -14,6 +14,8 @@ import java.util.stream.Stream;
  * LinkProvider defines an interface for managing and retrieving associations
  * between worlds and their respective {@link LinkTree} structures.
  * It allows querying linked worlds, establishing links, and managing portal relationships.
+ *
+ * @since 3.0.0
  */
 @NullMarked
 public interface LinkProvider {

--- a/api/src/main/java/net/thenextlvl/worlds/api/link/LinkProvider.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/link/LinkProvider.java
@@ -3,6 +3,7 @@ package net.thenextlvl.worlds.api.link;
 import net.kyori.adventure.key.Key;
 import org.bukkit.PortalType;
 import org.bukkit.World;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 
@@ -22,6 +23,7 @@ public interface LinkProvider {
      * @return a stream of all {@link LinkTree} instances
      */
     @Unmodifiable
+    @Contract(pure = true)
     Stream<LinkTree> getLinkTrees();
 
     /**
@@ -30,6 +32,7 @@ public interface LinkProvider {
      * @param key the key for which the associated LinkTree is to be retrieved
      * @return an Optional containing the associated LinkTree
      */
+    @Contract(pure = true)
     Optional<LinkTree> getLinkTree(Key key);
 
     /**
@@ -38,6 +41,7 @@ public interface LinkProvider {
      * @param world the world for which the associated LinkTree is to be retrieved
      * @return an Optional containing the associated LinkTree
      */
+    @Contract(pure = true)
     Optional<LinkTree> getLinkTree(World world);
 
     /**
@@ -49,6 +53,7 @@ public interface LinkProvider {
      * @param type  the type of portal that dictates the relationship between worlds (e.g., NETHER, ENDER)
      * @return an Optional containing the target world if available
      */
+    @Contract(pure = true)
     Optional<World> getTarget(World world, PortalType type);
 
     /**
@@ -95,6 +100,7 @@ public interface LinkProvider {
      * @param key the key to check for an associated LinkTree
      * @return whether the specified key has an associated LinkTree
      */
+    @Contract(pure = true)
     boolean hasLinkTree(Key key);
 
     /**
@@ -103,5 +109,6 @@ public interface LinkProvider {
      * @param world the world to check for an associated LinkTree
      * @return whether the specified world has an associated LinkTree
      */
+    @Contract(pure = true)
     boolean hasLinkTree(World world);
 }

--- a/api/src/main/java/net/thenextlvl/worlds/api/link/LinkTree.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/link/LinkTree.java
@@ -3,6 +3,7 @@ package net.thenextlvl.worlds.api.link;
 import net.kyori.adventure.key.Key;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -19,6 +20,7 @@ public interface LinkTree {
      *
      * @return the {@code World} associated with this {@code LinkTree}
      */
+    @Contract(pure = true)
     World getOverworld();
 
     /**
@@ -26,6 +28,7 @@ public interface LinkTree {
      *
      * @return an Optional containing the world, or empty if undefined or not loaded
      */
+    @Contract(pure = true)
     Optional<World> getNether();
 
     /**
@@ -33,6 +36,7 @@ public interface LinkTree {
      *
      * @return an Optional containing the key of the world, or empty if undefined
      */
+    @Contract(pure = true)
     Optional<Key> getPersistedNether();
 
     /**
@@ -41,6 +45,7 @@ public interface LinkTree {
      * @param world the {@link World} to be set, or null to clear the current world mapping
      * @return true if the world mapping was successfully set or cleared, false otherwise
      */
+    @Contract(mutates = "this")
     boolean setNether(@Nullable World world);
 
     /**
@@ -48,6 +53,7 @@ public interface LinkTree {
      *
      * @return an Optional containing the world, or empty if undefined or not loaded
      */
+    @Contract(pure = true)
     Optional<World> getEnd();
 
     /**
@@ -55,6 +61,7 @@ public interface LinkTree {
      *
      * @return an Optional containing the key of the world, or empty if undefined
      */
+    @Contract(pure = true)
     Optional<Key> getPersistedEnd();
 
     /**
@@ -63,6 +70,7 @@ public interface LinkTree {
      * @param world the {@link World} to be set, or null to clear the current world mapping
      * @return true if the world mapping was successfully set or cleared, false otherwise
      */
+    @Contract(mutates = "this")
     boolean setEnd(@Nullable World world);
 
     /**
@@ -70,6 +78,7 @@ public interface LinkTree {
      *
      * @return true if the link tree contains no associations, false otherwise
      */
+    @Contract(pure = true)
     boolean isEmpty();
 
     /**
@@ -78,6 +87,7 @@ public interface LinkTree {
      * @param key the key to check for containment within the link tree
      * @return true if the specified key is present in the link tree, false otherwise
      */
+    @Contract(pure = true)
     boolean contains(Key key);
 
     /**
@@ -86,6 +96,7 @@ public interface LinkTree {
      * @param world the world to check for containment within the link tree
      * @return true if the specified world is present in the link tree, false otherwise
      */
+    @Contract(pure = true)
     boolean contains(World world);
 
     /**
@@ -94,6 +105,7 @@ public interface LinkTree {
      * @param key the key associated with the world to be removed from the link tree
      * @return true if the key was successfully removed, false otherwise
      */
+    @Contract(mutates = "this")
     boolean remove(Key key);
 
     /**
@@ -102,6 +114,7 @@ public interface LinkTree {
      * @param world the world to be removed from the link tree
      * @return true if the world was successfully removed, false otherwise
      */
+    @Contract(mutates = "this")
     boolean remove(World world);
 
     /**
@@ -110,6 +123,7 @@ public interface LinkTree {
      * @param environment the environment for which the associated world is to be retrieved
      * @return an Optional containing the associated world, or an empty Optional if none exists
      */
+    @Contract(pure = true)
     Optional<World> getWorld(Environment environment);
 
     /**
@@ -117,5 +131,6 @@ public interface LinkTree {
      *
      * @return the {@link LinkProvider} managing associations and interactions for this LinkTree
      */
+    @Contract(pure = true)
     LinkProvider getLinkProvider();
 }

--- a/api/src/main/java/net/thenextlvl/worlds/api/link/LinkTree.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/link/LinkTree.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 /**
  * A LinkTree is a mapping between one Overworld, one Nether, and one End.
  * Links restore vanilla portal behavior.
+ *
+ * @since 3.0.0
  */
 @NullMarked
 public interface LinkTree {

--- a/api/src/main/java/net/thenextlvl/worlds/api/preset/Biome.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/preset/Biome.java
@@ -3,6 +3,7 @@ package net.thenextlvl.worlds.api.preset;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
 import net.kyori.adventure.key.Keyed;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -16,6 +17,7 @@ public record Biome(Key key) implements Keyed {
         return key().asString();
     }
 
+    @Contract(value = "_ -> new", pure = true)
     public static Biome literal(@KeyPattern String string) {
         return new Biome(Key.key(string));
     }

--- a/api/src/main/java/net/thenextlvl/worlds/api/preset/Biome.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/preset/Biome.java
@@ -6,6 +6,9 @@ import net.kyori.adventure.key.Keyed;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
+/**
+ * @since 2.0.0
+ */
 @NullMarked
 public record Biome(Key key) implements Keyed {
     public Biome(org.bukkit.block.Biome biome) {

--- a/api/src/main/java/net/thenextlvl/worlds/api/preset/Layer.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/preset/Layer.java
@@ -6,16 +6,19 @@ import org.bukkit.Material;
 import org.bukkit.block.BlockType;
 import org.jspecify.annotations.NullMarked;
 
+/**
+ * @since 2.0.0
+ */
 @NullMarked
 public record Layer(Key block, int height) {
     public Layer(Material material, int height) {
         this(material.key(), height);
     }
-    
+
     public Layer(BlockType blockType, int height) {
         this(blockType.key(), height);
     }
-    
+
     public Layer(@KeyPattern String block, int height) {
         this(Key.key(block), height);
     }

--- a/api/src/main/java/net/thenextlvl/worlds/api/preset/Preset.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/preset/Preset.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
  * <a href="https://minecraft.wiki/w/Superflat#Vanilla_superflat_level_generation_presets">Wiki</a>
  *
  * @see GeneratorType#FLAT
+ * @since 2.0.0
  */
 @NullMarked
 public class Preset {
@@ -57,6 +58,7 @@ public class Preset {
      * @param presetCode the preset code string to parse in the expected format
      * @return a {@code Preset} object configured with the layers and biome described in the preset code
      * @throws IllegalArgumentException if the preset code contains invalid materials or does not adhere to the required format
+     * @since 3.0.0
      */
     @Contract(pure = true)
     @SuppressWarnings("PatternValidation")
@@ -77,6 +79,7 @@ public class Preset {
      * Retrieves the name of the preset.
      *
      * @return the name of the preset as a {@code String}
+     * @since 3.0.0
      */
     @Contract(pure = true)
     public @Nullable String name() {
@@ -87,6 +90,7 @@ public class Preset {
      * Retrieves the biome associated with the preset.
      *
      * @return the biome as a {@code Biome} record
+     * @since 2.0.4
      */
     @Contract(pure = true)
     public Biome biome() {
@@ -98,6 +102,7 @@ public class Preset {
      *
      * @param biome the biome to be set, encapsulated in a {@code Biome} record
      * @return the current {@code Preset} instance, allowing for method chaining
+     * @since 2.0.4
      */
     @Contract(value = "_ -> this", mutates = "this")
     public Preset biome(Biome biome) {
@@ -109,6 +114,7 @@ public class Preset {
      * Determines whether lakes are enabled for the preset.
      *
      * @return true if lakes are enabled, false otherwise
+     * @since 2.0.4
      */
     @Contract(pure = true)
     public boolean lakes() {
@@ -120,6 +126,7 @@ public class Preset {
      *
      * @param lakes a boolean indicating whether lakes should be included
      * @return the current Preset instance, allowing for method chaining
+     * @since 2.0.4
      */
     @Contract(value = "_ -> this", mutates = "this")
     public Preset lakes(boolean lakes) {
@@ -131,6 +138,7 @@ public class Preset {
      * Determines whether features are enabled for the preset.
      *
      * @return true if features are enabled, false otherwise
+     * @since 2.0.4
      */
     @Contract(pure = true)
     public boolean features() {
@@ -142,6 +150,7 @@ public class Preset {
      *
      * @param features a boolean indicating whether features are enabled
      * @return the current Preset instance, allowing for method chaining
+     * @since 2.0.4
      */
     @Contract(value = "_ -> this", mutates = "this")
     public Preset features(boolean features) {
@@ -153,6 +162,7 @@ public class Preset {
      * Determines whether decoration is enabled for the preset.
      *
      * @return true if decoration is enabled, false otherwise
+     * @since 2.0.4
      */
     @Contract(pure = true)
     public boolean decoration() {
@@ -164,6 +174,7 @@ public class Preset {
      *
      * @param decoration a boolean indicating whether decoration is enabled
      * @return the current Preset instance, allowing for method chaining
+     * @since 2.0.4
      */
     @Contract(value = "_ -> this", mutates = "this")
     public Preset decoration(boolean decoration) {
@@ -175,6 +186,7 @@ public class Preset {
      * Retrieves the set of layers associated with the preset.
      *
      * @return a {@code Set} containing the layers of the preset
+     * @since 2.0.4
      */
     @Contract(pure = true)
     public @Unmodifiable Set<Layer> layers() {
@@ -186,6 +198,7 @@ public class Preset {
      *
      * @param layers the set of layers to be associated with the preset
      * @return the preset instance for method chaining
+     * @since 2.0.4
      */
     @Contract(value = "_ -> this", mutates = "this")
     public Preset layers(Set<Layer> layers) {
@@ -197,6 +210,7 @@ public class Preset {
      * Retrieves the set of structures associated with the preset.
      *
      * @return a {@code LinkedHashSet} containing the structures of the preset
+     * @since 2.0.4
      */
     @Contract(pure = true)
     public @Unmodifiable Set<Structure> structures() {
@@ -208,6 +222,7 @@ public class Preset {
      *
      * @param structures the set of structures to be associated with the preset
      * @return the preset instance for method chaining
+     * @since 2.0.4
      */
     @Contract(value = "_ -> this", mutates = "this")
     public Preset structures(Set<Structure> structures) {
@@ -220,6 +235,7 @@ public class Preset {
      *
      * @param layer the layer to add
      * @return the preset
+     * @since 2.0.4
      */
     @Contract(value = "_ -> this", mutates = "this")
     public Preset addLayer(Layer layer) {
@@ -232,6 +248,7 @@ public class Preset {
      *
      * @param structure the structure to add
      * @return the preset
+     * @since 2.0.4
      */
     @Contract(value = "_ -> this", mutates = "this")
     public Preset addStructure(Structure structure) {
@@ -248,6 +265,7 @@ public class Preset {
      * This is a lossy conversion. If you want to save this preset, use {@link #serialize()}.
      *
      * @return a {@code String} containing the serialized layers and biome information of the preset
+     * @since 3.0.0
      */
     @Contract(pure = true)
     public String toPresetCode() {

--- a/api/src/main/java/net/thenextlvl/worlds/api/preset/Preset.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/preset/Preset.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import net.thenextlvl.worlds.api.generator.GeneratorType;
 import org.bukkit.Material;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -57,6 +58,7 @@ public class Preset {
      * @return a {@code Preset} object configured with the layers and biome described in the preset code
      * @throws IllegalArgumentException if the preset code contains invalid materials or does not adhere to the required format
      */
+    @Contract(pure = true)
     @SuppressWarnings("PatternValidation")
     public static Preset parse(String presetCode) {
         var strings = presetCode.split(";", 2);
@@ -76,6 +78,7 @@ public class Preset {
      *
      * @return the name of the preset as a {@code String}
      */
+    @Contract(pure = true)
     public @Nullable String name() {
         return name;
     }
@@ -85,6 +88,7 @@ public class Preset {
      *
      * @return the biome as a {@code Biome} record
      */
+    @Contract(pure = true)
     public Biome biome() {
         return biome;
     }
@@ -95,6 +99,7 @@ public class Preset {
      * @param biome the biome to be set, encapsulated in a {@code Biome} record
      * @return the current {@code Preset} instance, allowing for method chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public Preset biome(Biome biome) {
         this.biome = biome;
         return this;
@@ -105,6 +110,7 @@ public class Preset {
      *
      * @return true if lakes are enabled, false otherwise
      */
+    @Contract(pure = true)
     public boolean lakes() {
         return lakes;
     }
@@ -115,6 +121,7 @@ public class Preset {
      * @param lakes a boolean indicating whether lakes should be included
      * @return the current Preset instance, allowing for method chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public Preset lakes(boolean lakes) {
         this.lakes = lakes;
         return this;
@@ -125,6 +132,7 @@ public class Preset {
      *
      * @return true if features are enabled, false otherwise
      */
+    @Contract(pure = true)
     public boolean features() {
         return features;
     }
@@ -135,6 +143,7 @@ public class Preset {
      * @param features a boolean indicating whether features are enabled
      * @return the current Preset instance, allowing for method chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public Preset features(boolean features) {
         this.features = features;
         return this;
@@ -145,6 +154,7 @@ public class Preset {
      *
      * @return true if decoration is enabled, false otherwise
      */
+    @Contract(pure = true)
     public boolean decoration() {
         return decoration;
     }
@@ -155,6 +165,7 @@ public class Preset {
      * @param decoration a boolean indicating whether decoration is enabled
      * @return the current Preset instance, allowing for method chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public Preset decoration(boolean decoration) {
         this.decoration = decoration;
         return this;
@@ -165,6 +176,7 @@ public class Preset {
      *
      * @return a {@code Set} containing the layers of the preset
      */
+    @Contract(pure = true)
     public @Unmodifiable Set<Layer> layers() {
         return Set.copyOf(layers);
     }
@@ -175,6 +187,7 @@ public class Preset {
      * @param layers the set of layers to be associated with the preset
      * @return the preset instance for method chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public Preset layers(Set<Layer> layers) {
         this.layers = new LinkedHashSet<>(layers);
         return this;
@@ -185,6 +198,7 @@ public class Preset {
      *
      * @return a {@code LinkedHashSet} containing the structures of the preset
      */
+    @Contract(pure = true)
     public @Unmodifiable Set<Structure> structures() {
         return Set.copyOf(structures);
     }
@@ -195,6 +209,7 @@ public class Preset {
      * @param structures the set of structures to be associated with the preset
      * @return the preset instance for method chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public Preset structures(Set<Structure> structures) {
         this.structures = new LinkedHashSet<>(structures);
         return this;
@@ -206,6 +221,7 @@ public class Preset {
      * @param layer the layer to add
      * @return the preset
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public Preset addLayer(Layer layer) {
         layers.add(layer);
         return this;
@@ -217,6 +233,7 @@ public class Preset {
      * @param structure the structure to add
      * @return the preset
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public Preset addStructure(Structure structure) {
         structures.add(structure);
         return this;
@@ -232,6 +249,7 @@ public class Preset {
      *
      * @return a {@code String} containing the serialized layers and biome information of the preset
      */
+    @Contract(pure = true)
     public String toPresetCode() {
         var layers = this.layers.stream()
                 .map(Layer::toString)
@@ -246,6 +264,7 @@ public class Preset {
      * @return the serialized preset as a JsonObject
      * @see #deserialize(JsonObject)
      */
+    @Contract(value = " -> new", pure = true)
     public JsonObject serialize() {
         var root = new JsonObject();
         var layers = new JsonArray();
@@ -277,6 +296,7 @@ public class Preset {
      * @see #serialize()
      */
     @SuppressWarnings("PatternValidation")
+    @Contract(value = "_ -> new", pure = true)
     public static Preset deserialize(JsonObject object) throws IllegalArgumentException {
         Preconditions.checkArgument(object.has("layers"), "Missing layers");
         var preset = new Preset(object.has("name") ? object.get("name").getAsString() : null);

--- a/api/src/main/java/net/thenextlvl/worlds/api/preset/Presets.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/preset/Presets.java
@@ -6,6 +6,9 @@ import org.jspecify.annotations.NullMarked;
 
 import java.util.Set;
 
+/**
+ * @since 2.0.0
+ */
 @NullMarked
 public class Presets {
     public static final Preset BOTTOMLESS_PIT = new Preset("Bottomless Pit")

--- a/api/src/main/java/net/thenextlvl/worlds/api/preset/Structure.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/preset/Structure.java
@@ -3,6 +3,7 @@ package net.thenextlvl.worlds.api.preset;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
 import net.kyori.adventure.key.Keyed;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -16,6 +17,7 @@ public record Structure(Key key) implements Keyed {
         this(Key.key(string));
     }
 
+    @Contract(value = "_ -> new", pure = true)
     public static Structure literal(@KeyPattern String structure) {
         return new Structure(Key.key(structure));
     }

--- a/api/src/main/java/net/thenextlvl/worlds/api/preset/Structure.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/preset/Structure.java
@@ -6,6 +6,9 @@ import net.kyori.adventure.key.Keyed;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
+/**
+ * @since 2.0.0
+ */
 @NullMarked
 public record Structure(Key key) implements Keyed {
     @Override

--- a/api/src/main/java/net/thenextlvl/worlds/api/view/GeneratorView.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/view/GeneratorView.java
@@ -1,6 +1,7 @@
 package net.thenextlvl.worlds.api.view;
 
 import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -11,6 +12,8 @@ public interface GeneratorView {
      * @param plugin the plugin to check for an associated generator
      * @return true if the plugin has a generator, otherwise false
      */
+    
+    @Contract(pure = true)
     boolean hasGenerator(Plugin plugin);
 
     /**
@@ -19,6 +22,7 @@ public interface GeneratorView {
      * @param clazz the class of the plugin to check
      * @return true if the plugin class overrides the method for providing a ChunkGenerator, otherwise false
      */
+    @Contract(pure = true)
     boolean hasChunkGenerator(Class<? extends Plugin> clazz);
 
     /**
@@ -27,5 +31,6 @@ public interface GeneratorView {
      * @param clazz the class of the plugin to check
      * @return true if the plugin class overrides the method to provide a default biome provider, otherwise false
      */
+    @Contract(pure = true)
     boolean hasBiomeProvider(Class<? extends Plugin> clazz);
 }

--- a/api/src/main/java/net/thenextlvl/worlds/api/view/GeneratorView.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/view/GeneratorView.java
@@ -4,6 +4,9 @@ import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
+/**
+ * @since 2.0.0
+ */
 @NullMarked
 public interface GeneratorView {
     /**
@@ -12,7 +15,7 @@ public interface GeneratorView {
      * @param plugin the plugin to check for an associated generator
      * @return true if the plugin has a generator, otherwise false
      */
-    
+
     @Contract(pure = true)
     boolean hasGenerator(Plugin plugin);
 

--- a/api/src/main/java/net/thenextlvl/worlds/api/view/LevelView.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/view/LevelView.java
@@ -201,9 +201,11 @@ public interface LevelView {
      * @param world the world to back up
      * @return the size of the created backup in bytes
      * @throws IOException if an I/O error occurs while creating the backup
+     * @deprecated use {@link #backupAsync(World)}
      */
     @Contract(mutates = "io,param1")
     @SuppressWarnings("RedundantThrows")
+    @Deprecated(forRemoval = true, since = "3.3.1")
     default long backup(World world) throws IOException {
         return backupAsync(world).join();
     }

--- a/api/src/main/java/net/thenextlvl/worlds/api/view/LevelView.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/view/LevelView.java
@@ -5,6 +5,7 @@ import net.thenextlvl.worlds.api.level.Level;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 
@@ -26,6 +27,7 @@ public interface LevelView {
      *
      * @return the {@link Path} representing the backup folder
      */
+    @Contract(pure = true)
     Path getBackupFolder();
 
     /**
@@ -33,6 +35,7 @@ public interface LevelView {
      *
      * @return the {@link Path} representing the world container directory
      */
+    @Contract(pure = true)
     Path getWorldContainer();
 
     /**
@@ -42,6 +45,7 @@ public interface LevelView {
      * @return an {@code Optional} containing the {@code Level.Builder} if the directory represents a valid level,
      * or {@link Optional#empty()} if the directory is invalid
      */
+    @Contract(value = "_ -> new", pure = true)
     Optional<Level.Builder> read(Path directory);
 
     /**
@@ -51,6 +55,7 @@ public interface LevelView {
      * @return an {@code Optional} containing the associated {@code JavaPlugin}, or {@link Optional#empty()}
      * if the world does not have a generator or if the generator is not associated with a plugin
      */
+    @Contract(pure = true)
     Optional<JavaPlugin> getGenerator(World world);
 
     /**
@@ -62,6 +67,7 @@ public interface LevelView {
      * or an empty set if no valid levels are found or if an error occurs while accessing the filesystem.
      */
     @Unmodifiable
+    @Contract(pure = true)
     Set<Path> listLevels();
 
     /**
@@ -71,6 +77,7 @@ public interface LevelView {
      * @param level the path to the level directory to be checked
      * @return true if the level can be loaded, otherwise false
      */
+    @Contract(pure = true)
     boolean canLoad(Path level);
 
     /**
@@ -79,6 +86,7 @@ public interface LevelView {
      * @param level the path to the directory to be checked
      * @return true if the level directory contains a {@code DIM1} folder, otherwise false
      */
+    @Contract(pure = true)
     boolean hasEndDimension(Path level);
 
     /**
@@ -87,6 +95,7 @@ public interface LevelView {
      * @param level the path to the directory to be checked
      * @return true if the level directory contains a {@code DIM-1} folder, otherwise false
      */
+    @Contract(pure = true)
     boolean hasNetherDimension(Path level);
 
     /**
@@ -96,6 +105,7 @@ public interface LevelView {
      * @return {@code true} if the directory contains a {@code level.dat}
      * or {@code level.dat_old}, otherwise {@code false}
      */
+    @Contract(pure = true)
     boolean isLevel(Path path);
 
     /**
@@ -106,6 +116,7 @@ public interface LevelView {
      * @return true if the world was successfully unloaded, otherwise false
      * @deprecated use {@link #unloadAsync(World, boolean)}
      */
+    @Contract(mutates = "io,param1")
     @Deprecated(forRemoval = true, since = "3.2.0")
     default boolean unload(World world, boolean save) {
         return unloadAsync(world, save).join();
@@ -118,6 +129,7 @@ public interface LevelView {
      * @param save  whether changes to the world should be saved before unloading
      * @return A {@code CompletableFuture} completing with true if the world was successfully unloaded, otherwise false
      */
+    @Contract(mutates = "io,param1")
     CompletableFuture<Boolean> unloadAsync(World world, boolean save);
 
     /**
@@ -127,6 +139,7 @@ public interface LevelView {
      * @param flush whether to flush pending changes to disk immediately
      * @deprecated use {@link #saveAsync(World, boolean)}
      */
+    @Contract(mutates = "io,param1")
     @Deprecated(forRemoval = true, since = "3.2.0")
     default void save(World world, boolean flush) {
         saveAsync(world, flush).join();
@@ -139,6 +152,7 @@ public interface LevelView {
      * @param flush whether to flush pending changes to disk immediately
      * @return A {@code CompletableFuture} that might complete exceptionally
      */
+    @Contract(mutates = "io,param1")
     CompletableFuture<Void> saveAsync(World world, boolean flush);
 
     /**
@@ -148,6 +162,7 @@ public interface LevelView {
      * @param async whether the save operation should be performed asynchronously
      * @deprecated use {@link #saveLevelDataAsync(World)}
      */
+    @Contract(mutates = "io,param1")
     @Deprecated(forRemoval = true, since = "3.2.0")
     default void saveLevelData(World world, boolean async) {
         var future = saveLevelDataAsync(world);
@@ -159,6 +174,7 @@ public interface LevelView {
      *
      * @param world the world whose level data should be saved
      */
+    @Contract(mutates = "io,param1")
     CompletableFuture<Void> saveLevelDataAsync(World world);
 
     /**
@@ -167,6 +183,7 @@ public interface LevelView {
      * @param world the world to check
      * @return true if the world is enabled, false otherwise
      */
+    @Contract(pure = true)
     boolean isEnabled(World world);
 
     /**
@@ -175,6 +192,7 @@ public interface LevelView {
      * @param world   the world to enable or disable
      * @param enabled true to enable the world, false to disable it
      */
+    @Contract(mutates = "param1")
     void setEnabled(World world, boolean enabled);
 
     /**
@@ -184,6 +202,7 @@ public interface LevelView {
      * @return the size of the created backup in bytes
      * @throws IOException if an I/O error occurs while creating the backup
      */
+    @Contract(mutates = "io,param1")
     @SuppressWarnings("RedundantThrows")
     default long backup(World world) throws IOException {
         return backupAsync(world).join();
@@ -197,6 +216,7 @@ public interface LevelView {
      * @param world the world to back up
      * @return A {@code CompletableFuture} completing with the size of the created backup in bytes
      */
+    @Contract(mutates = "io,param1")
     CompletableFuture<Long> backupAsync(World world);
 
     /**
@@ -222,6 +242,7 @@ public interface LevelView {
      * @see WorldCloneEvent#isFullClone()
      * @deprecated use {@link #cloneAsync(World, Consumer, boolean)}
      */
+    @Contract(mutates = "io,param1")
     @SuppressWarnings("RedundantThrows")
     @Deprecated(forRemoval = true, since = "3.2.0")
     default Optional<World> clone(World world, Consumer<Level.Builder> builder, boolean full) throws IllegalArgumentException, IllegalStateException, IOException {
@@ -248,6 +269,7 @@ public interface LevelView {
      * @return A {@code CompletableFuture} completing with the cloned world
      * @see WorldCloneEvent#isFullClone()
      */
+    @Contract(mutates = "io,param1")
     CompletableFuture<World> cloneAsync(World world, Consumer<Level.Builder> builder, boolean full);
 
     /**
@@ -260,6 +282,7 @@ public interface LevelView {
      * @return a {@code DeletionResult} indicating the outcome of the deletion process.
      * @deprecated use {@link #deleteAsync(World, boolean)}
      */
+    @Contract(mutates = "io,param1")
     @Deprecated(forRemoval = true, since = "3.2.0")
     default DeletionResult delete(World world, boolean schedule) {
         return deleteAsync(world, schedule).join();
@@ -275,6 +298,7 @@ public interface LevelView {
      * @return A {@code CompletableFuture} completing with a {@code DeletionResult}
      * indicating the outcome of the deletion process.
      */
+    @Contract(mutates = "io,param1")
     CompletableFuture<DeletionResult> deleteAsync(World world, boolean schedule);
 
     /**
@@ -283,6 +307,7 @@ public interface LevelView {
      * @param world the world for which the scheduled deletion should be canceled
      * @return true if the scheduled deletion was successfully canceled, false if no deletion was scheduled
      */
+    @Contract(mutates = "this")
     boolean cancelScheduledDeletion(World world);
 
     /**
@@ -291,6 +316,7 @@ public interface LevelView {
      * @param world the world to check for a scheduled deletion
      * @return true if a deletion process is scheduled for the world, otherwise false
      */
+    @Contract(pure = true)
     boolean isDeletionScheduled(World world);
 
     /**
@@ -302,6 +328,7 @@ public interface LevelView {
      * @return a {@code DeletionResult} indicating the outcome of the regeneration process.
      * @deprecated use {@link #regenerateAsync(World, boolean)}
      */
+    @Contract(mutates = "io,param1")
     @Deprecated(forRemoval = true, since = "3.2.0")
     default DeletionResult regenerate(World world, boolean schedule) {
         return regenerateAsync(world, schedule).join();
@@ -316,6 +343,7 @@ public interface LevelView {
      * @return a {@code CompletableFuture} completing with a
      * {@code DeletionResult} indicating the outcome of the regeneration process.
      */
+    @Contract(mutates = "io,param1")
     CompletableFuture<DeletionResult> regenerateAsync(World world, boolean schedule);
 
     /**
@@ -324,6 +352,7 @@ public interface LevelView {
      * @param world the world for which the scheduled regeneration should be canceled
      * @return true if the scheduled regeneration was successfully canceled, false if no regeneration was scheduled
      */
+    @Contract(mutates = "this")
     boolean cancelScheduledRegeneration(World world);
 
     /**
@@ -332,6 +361,7 @@ public interface LevelView {
      * @param world the world to check for a scheduled regeneration
      * @return true if a regeneration process is scheduled for the world, otherwise false
      */
+    @Contract(pure = true)
     boolean isRegenerationScheduled(World world);
 
     /**
@@ -368,6 +398,7 @@ public interface LevelView {
          *
          * @return true if the result is either {@code SUCCESS} or {@code SCHEDULED}, otherwise false
          */
+        @Contract(pure = true)
         public boolean isSuccess() {
             return this == SUCCESS || this == SCHEDULED;
         }

--- a/api/src/main/java/net/thenextlvl/worlds/api/view/LevelView.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/view/LevelView.java
@@ -19,6 +19,8 @@ import java.util.function.Consumer;
 /**
  * Interface representing a view for managing levels in a server environment.
  * It provides methods for reading, validating, and managing world directories and data.
+ *
+ * @since 2.0.0
  */
 @NullMarked
 public interface LevelView {
@@ -26,6 +28,7 @@ public interface LevelView {
      * Retrieves the path to the backup folder.
      *
      * @return the {@link Path} representing the backup folder
+     * @since 3.0.0
      */
     @Contract(pure = true)
     Path getBackupFolder();
@@ -34,6 +37,7 @@ public interface LevelView {
      * Retrieves the path to the world container directory.
      *
      * @return the {@link Path} representing the world container directory
+     * @since 3.0.0
      */
     @Contract(pure = true)
     Path getWorldContainer();
@@ -44,6 +48,7 @@ public interface LevelView {
      * @param directory the directory containing the level data to be read
      * @return an {@code Optional} containing the {@code Level.Builder} if the directory represents a valid level,
      * or {@link Optional#empty()} if the directory is invalid
+     * @since 3.0.0
      */
     @Contract(value = "_ -> new", pure = true)
     Optional<Level.Builder> read(Path directory);
@@ -54,6 +59,7 @@ public interface LevelView {
      * @param world the world whose generator plugin is to be retrieved
      * @return an {@code Optional} containing the associated {@code JavaPlugin}, or {@link Optional#empty()}
      * if the world does not have a generator or if the generator is not associated with a plugin
+     * @since 3.0.0
      */
     @Contract(pure = true)
     Optional<JavaPlugin> getGenerator(World world);
@@ -65,6 +71,7 @@ public interface LevelView {
      *
      * @return an unmodifiable set of {@link Path} objects representing valid level directories,
      * or an empty set if no valid levels are found or if an error occurs while accessing the filesystem.
+     * @since 3.0.0
      */
     @Unmodifiable
     @Contract(pure = true)
@@ -76,6 +83,7 @@ public interface LevelView {
      *
      * @param level the path to the level directory to be checked
      * @return true if the level can be loaded, otherwise false
+     * @since 3.0.0
      */
     @Contract(pure = true)
     boolean canLoad(Path level);
@@ -85,6 +93,7 @@ public interface LevelView {
      *
      * @param level the path to the directory to be checked
      * @return true if the level directory contains a {@code DIM1} folder, otherwise false
+     * @since 3.0.0
      */
     @Contract(pure = true)
     boolean hasEndDimension(Path level);
@@ -94,6 +103,7 @@ public interface LevelView {
      *
      * @param level the path to the directory to be checked
      * @return true if the level directory contains a {@code DIM-1} folder, otherwise false
+     * @since 3.0.0
      */
     @Contract(pure = true)
     boolean hasNetherDimension(Path level);
@@ -104,6 +114,7 @@ public interface LevelView {
      * @param path the path to the directory being checked
      * @return {@code true} if the directory contains a {@code level.dat}
      * or {@code level.dat_old}, otherwise {@code false}
+     * @since 3.0.0
      */
     @Contract(pure = true)
     boolean isLevel(Path path);
@@ -114,6 +125,7 @@ public interface LevelView {
      * @param world the world to be unloaded
      * @param save  whether changes to the world should be saved before unloading
      * @return true if the world was successfully unloaded, otherwise false
+     * @since 3.0.0
      * @deprecated use {@link #unloadAsync(World, boolean)}
      */
     @Contract(mutates = "io,param1")
@@ -128,6 +140,7 @@ public interface LevelView {
      * @param world the world to be unloaded
      * @param save  whether changes to the world should be saved before unloading
      * @return A {@code CompletableFuture} completing with true if the world was successfully unloaded, otherwise false
+     * @since 3.2.0
      */
     @Contract(mutates = "io,param1")
     CompletableFuture<Boolean> unloadAsync(World world, boolean save);
@@ -137,6 +150,7 @@ public interface LevelView {
      *
      * @param world the world to be saved
      * @param flush whether to flush pending changes to disk immediately
+     * @since 3.0.0
      * @deprecated use {@link #saveAsync(World, boolean)}
      */
     @Contract(mutates = "io,param1")
@@ -151,6 +165,7 @@ public interface LevelView {
      * @param world the world to be saved
      * @param flush whether to flush pending changes to disk immediately
      * @return A {@code CompletableFuture} that might complete exceptionally
+     * @since 3.2.0
      */
     @Contract(mutates = "io,param1")
     CompletableFuture<Void> saveAsync(World world, boolean flush);
@@ -173,6 +188,7 @@ public interface LevelView {
      * Saves the {@code level.dat} of the specified world to disk.
      *
      * @param world the world whose level data should be saved
+     * @since 3.2.0
      */
     @Contract(mutates = "io,param1")
     CompletableFuture<Void> saveLevelDataAsync(World world);
@@ -182,6 +198,7 @@ public interface LevelView {
      *
      * @param world the world to check
      * @return true if the world is enabled, false otherwise
+     * @since 3.2.0
      */
     @Contract(pure = true)
     boolean isEnabled(World world);
@@ -191,6 +208,7 @@ public interface LevelView {
      *
      * @param world   the world to enable or disable
      * @param enabled true to enable the world, false to disable it
+     * @since 3.2.0
      */
     @Contract(mutates = "param1")
     void setEnabled(World world, boolean enabled);
@@ -201,6 +219,7 @@ public interface LevelView {
      * @param world the world to back up
      * @return the size of the created backup in bytes
      * @throws IOException if an I/O error occurs while creating the backup
+     * @since 3.0.0
      * @deprecated use {@link #backupAsync(World)}
      */
     @Contract(mutates = "io,param1")
@@ -217,6 +236,7 @@ public interface LevelView {
      *
      * @param world the world to back up
      * @return A {@code CompletableFuture} completing with the size of the created backup in bytes
+     * @since 3.2.0
      */
     @Contract(mutates = "io,param1")
     CompletableFuture<Long> backupAsync(World world);
@@ -242,6 +262,7 @@ public interface LevelView {
      * @throws IllegalStateException    if the target directory already exists
      * @throws IOException              if an I/O error occurs during the cloning process
      * @see WorldCloneEvent#isFullClone()
+     * @since 3.0.0
      * @deprecated use {@link #cloneAsync(World, Consumer, boolean)}
      */
     @Contract(mutates = "io,param1")
@@ -270,6 +291,7 @@ public interface LevelView {
      * @param full    whether to fully clone including regions, entities..., or only the {@code level.dat}
      * @return A {@code CompletableFuture} completing with the cloned world
      * @see WorldCloneEvent#isFullClone()
+     * @since 3.2.0
      */
     @Contract(mutates = "io,param1")
     CompletableFuture<World> cloneAsync(World world, Consumer<Level.Builder> builder, boolean full);
@@ -282,6 +304,7 @@ public interface LevelView {
      * @param schedule if true, the deletion process will be scheduled for a later operation
      *                 (e.g., during server shutdown); if false, the deletion will be attempted immediately
      * @return a {@code DeletionResult} indicating the outcome of the deletion process.
+     * @since 3.0.0
      * @deprecated use {@link #deleteAsync(World, boolean)}
      */
     @Contract(mutates = "io,param1")
@@ -299,6 +322,7 @@ public interface LevelView {
      *                 (e.g., during server shutdown); if false, the deletion will be attempted immediately
      * @return A {@code CompletableFuture} completing with a {@code DeletionResult}
      * indicating the outcome of the deletion process.
+     * @since 3.2.0
      */
     @Contract(mutates = "io,param1")
     CompletableFuture<DeletionResult> deleteAsync(World world, boolean schedule);
@@ -308,6 +332,7 @@ public interface LevelView {
      *
      * @param world the world for which the scheduled deletion should be canceled
      * @return true if the scheduled deletion was successfully canceled, false if no deletion was scheduled
+     * @since 3.0.0
      */
     @Contract(mutates = "this")
     boolean cancelScheduledDeletion(World world);
@@ -317,6 +342,7 @@ public interface LevelView {
      *
      * @param world the world to check for a scheduled deletion
      * @return true if a deletion process is scheduled for the world, otherwise false
+     * @since 3.0.0
      */
     @Contract(pure = true)
     boolean isDeletionScheduled(World world);
@@ -328,6 +354,7 @@ public interface LevelView {
      * @param schedule if true, the regeneration will be scheduled for later execution;
      *                 if false, the regeneration will be attempted immediately
      * @return a {@code DeletionResult} indicating the outcome of the regeneration process.
+     * @since 3.0.0
      * @deprecated use {@link #regenerateAsync(World, boolean)}
      */
     @Contract(mutates = "io,param1")
@@ -344,6 +371,7 @@ public interface LevelView {
      *                 if false, the regeneration will be attempted immediately
      * @return a {@code CompletableFuture} completing with a
      * {@code DeletionResult} indicating the outcome of the regeneration process.
+     * @since 3.2.0
      */
     @Contract(mutates = "io,param1")
     CompletableFuture<DeletionResult> regenerateAsync(World world, boolean schedule);
@@ -353,6 +381,7 @@ public interface LevelView {
      *
      * @param world the world for which the scheduled regeneration should be canceled
      * @return true if the scheduled regeneration was successfully canceled, false if no regeneration was scheduled
+     * @since 3.0.0
      */
     @Contract(mutates = "this")
     boolean cancelScheduledRegeneration(World world);
@@ -362,12 +391,15 @@ public interface LevelView {
      *
      * @param world the world to check for a scheduled regeneration
      * @return true if a regeneration process is scheduled for the world, otherwise false
+     * @since 3.0.0
      */
     @Contract(pure = true)
     boolean isRegenerationScheduled(World world);
 
     /**
      * Represents the possible outcomes of a world deletion process.
+     *
+     * @since 3.0.0
      */
     enum DeletionResult {
         /**


### PR DESCRIPTION
- Added `@since` tags to all classes and methods
- Added method contracts indicating purity and mutability to all methods where applicable
- Deprecated `LevelView#backup(World)` in favor of `LevelView#backupAsync(World)`
- Deprecated spawn chunk-related methods due to upcoming Minecraft changes