### PR TITLE
Added name option to import command

### DIFF
--- a/src/main/java/net/thenextlvl/worlds/command/WorldImportCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldImportCommand.java
@@ -15,7 +15,6 @@ import net.thenextlvl.worlds.api.generator.LevelStem;
 import net.thenextlvl.worlds.api.level.Level;
 import net.thenextlvl.worlds.command.argument.LevelStemArgument;
 import net.thenextlvl.worlds.command.suggestion.LevelSuggestionProvider;
-import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -43,7 +42,7 @@ class WorldImportCommand {
 
     private static RequiredArgumentBuilder<CommandSourceStack, Key> importKeyed(WorldsPlugin plugin) {
         return keyArgument().then(importDimension(plugin)).executes(context -> {
-            var key = context.getArgument("key", NamespacedKey.class);
+            var key = context.getArgument("key", Key.class);
             return execute(context, key, null, null, plugin);
         });
     }
@@ -56,7 +55,7 @@ class WorldImportCommand {
 
     private static int importWorld(WorldsPlugin plugin, CommandContext<CommandSourceStack> context) {
         var levelStem = context.getArgument("level-type", LevelStem.class);
-        var key = context.getArgument("key", NamespacedKey.class);
+        var key = context.getArgument("key", Key.class);
         return execute(context, key, levelStem, null, plugin);
     }
 
@@ -64,12 +63,12 @@ class WorldImportCommand {
         return generatorArgument(plugin).executes(context -> {
             var levelStem = context.getArgument("level-type", LevelStem.class);
             var generator = context.getArgument("generator", Generator.class);
-            var key = context.getArgument("key", NamespacedKey.class);
+            var key = context.getArgument("key", Key.class);
             return execute(context, key, levelStem, generator, plugin);
         });
     }
 
-    private static int execute(CommandContext<CommandSourceStack> context, @Nullable NamespacedKey key,
+    private static int execute(CommandContext<CommandSourceStack> context, @Nullable Key key,
                                @Nullable LevelStem levelStem, @Nullable Generator generator, WorldsPlugin plugin) {
         var name = context.getArgument("world", String.class);
         var build = plugin.levelView().read(Path.of(name))


### PR DESCRIPTION
Introduced `name`, `key`, `generator`, and `level-type` as command arguments for enhanced world import customization. Refactored argument handling to improve code readability and maintainability.