### PR TITLE
Improved `/world create` command

### DIFF
--- a/api/src/main/java/net/thenextlvl/worlds/api/generator/GeneratorType.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/generator/GeneratorType.java
@@ -13,42 +13,42 @@ import java.util.Optional;
  */
 @NullMarked
 @ApiStatus.Experimental
-public record GeneratorType(Key key) implements Keyed {
+public record GeneratorType(Key key, String name) implements Keyed {
     /**
      * Represents the "amplified" generator type.
      * <a href="https://minecraft.wiki/w/Amplified">Wiki</a>
      */
-    public static final GeneratorType AMPLIFIED = new GeneratorType(Key.key("minecraft", "amplified"));
+    public static final GeneratorType AMPLIFIED = new GeneratorType(Key.key("minecraft", "amplified"), "amplified");
 
     /**
      * Represents the "debug" generator type.
      * <a href="https://minecraft.wiki/w/Dimension_definition#debug">Wiki</a>
      */
-    public static final GeneratorType DEBUG = new GeneratorType(Key.key("minecraft", "debug"));
+    public static final GeneratorType DEBUG = new GeneratorType(Key.key("minecraft", "debug"), "debug");
 
     /**
      * Represents the "flat" generator type.
      * <a href="https://minecraft.wiki/w/Dimension_definition#flat">Wiki</a>
      */
-    public static final GeneratorType FLAT = new GeneratorType(Key.key("minecraft", "flat"));
+    public static final GeneratorType FLAT = new GeneratorType(Key.key("minecraft", "flat"), "flat");
 
     /**
      * Represents the "large_biomes" generator type.
      * <a href="https://minecraft.wiki/w/Large_Biomes">Wiki</a>
      */
-    public static final GeneratorType LARGE_BIOMES = new GeneratorType(Key.key("minecraft", "large_biomes"));
+    public static final GeneratorType LARGE_BIOMES = new GeneratorType(Key.key("minecraft", "large_biomes"), "large-biomes");
 
     /**
      * Represents the "noise" generator type.
      * <a href="https://minecraft.wiki/w/Dimension_definition#noise">Wiki</a>
      */
-    public static final GeneratorType NORMAL = new GeneratorType(Key.key("minecraft", "noise"));
+    public static final GeneratorType NORMAL = new GeneratorType(Key.key("minecraft", "noise"), "normal");
 
     /**
      * Represents the "noise" generator type.
      * <a href="https://minecraft.wiki/w/Dimension_definition#fixed">Wiki</a>
      */
-    public static final GeneratorType SINGLE_BIOME = new GeneratorType(Key.key("minecraft", "fixed"));
+    public static final GeneratorType SINGLE_BIOME = new GeneratorType(Key.key("minecraft", "fixed"), "single-biome");
 
     @ApiStatus.Internal
     @Contract(pure = true)
@@ -60,13 +60,13 @@ public record GeneratorType(Key key) implements Keyed {
     }
 
     @Contract(pure = true)
-    public static Optional<GeneratorType> getByKey(Key key) {
-        if (key.equals(AMPLIFIED.key())) return Optional.of(AMPLIFIED);
-        if (key.equals(DEBUG.key())) return Optional.of(DEBUG);
-        if (key.equals(FLAT.key())) return Optional.of(FLAT);
-        if (key.equals(LARGE_BIOMES.key())) return Optional.of(LARGE_BIOMES);
-        if (key.equals(NORMAL.key())) return Optional.of(NORMAL);
-        if (key.equals(SINGLE_BIOME.key())) return Optional.of(SINGLE_BIOME);
+    public static Optional<GeneratorType> getByName(String name) {
+        if (name.equals(AMPLIFIED.name())) return Optional.of(AMPLIFIED);
+        if (name.equals(DEBUG.name())) return Optional.of(DEBUG);
+        if (name.equals(FLAT.name())) return Optional.of(FLAT);
+        if (name.equals(LARGE_BIOMES.name())) return Optional.of(LARGE_BIOMES);
+        if (name.equals(NORMAL.name())) return Optional.of(NORMAL);
+        if (name.equals(SINGLE_BIOME.name())) return Optional.of(SINGLE_BIOME);
         return Optional.empty();
     }
 }

--- a/src/main/java/net/thenextlvl/worlds/command/WorldCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldCommand.java
@@ -9,6 +9,7 @@ import net.kyori.adventure.key.Key;
 import net.thenextlvl.worlds.WorldsPlugin;
 import net.thenextlvl.worlds.api.generator.Generator;
 import net.thenextlvl.worlds.command.argument.GeneratorArgument;
+import net.thenextlvl.worlds.command.argument.KeyArgument;
 import net.thenextlvl.worlds.command.suggestion.WorldSuggestionProvider;
 import org.bukkit.World;
 import org.jspecify.annotations.NullMarked;
@@ -45,7 +46,7 @@ public class WorldCommand {
     }
 
     public static RequiredArgumentBuilder<CommandSourceStack, Key> keyArgument() {
-        return Commands.argument("key", ArgumentTypes.key());
+        return Commands.argument("key", new KeyArgument());
     }
 
     public static RequiredArgumentBuilder<CommandSourceStack, Generator> generatorArgument(WorldsPlugin plugin) {

--- a/src/main/java/net/thenextlvl/worlds/command/WorldCreateCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldCreateCommand.java
@@ -50,13 +50,15 @@ class WorldCreateCommand extends OptionCommand {
                 new Option("preset", new WorldPresetArgument(plugin)),
                 new Option("type", new GeneratorTypeArgument(plugin))
         ), builder -> addOptions(builder, false, Set.of(
+                new Option("bonus-chest", BoolArgumentType.bool()),
+                new Option("hardcore", BoolArgumentType.bool()),
                 new Option("dimension", new LevelStemArgument(plugin)),
                 new Option("key", ArgumentTypes.key()),
                 new Option("seed", new SeedArgument()),
                 new Option("structures", BoolArgumentType.bool())
         ), null));
 
-        return name;
+        return name.executes(this::execute);
     }
 
     @Override
@@ -75,6 +77,8 @@ class WorldCreateCommand extends OptionCommand {
         var preset = tryGetArgument(context, "preset", Preset.class);
         var seed = tryGetArgument(context, "seed", Long.class);
         var structures = tryGetArgument(context, "structures", Boolean.class);
+        var bonusChest = tryGetArgument(context, "bonus-chest", Boolean.class);
+        var hardcore = tryGetArgument(context, "hardcore", Boolean.class);
         var type = tryGetArgument(context, "type", GeneratorType.class);
 
         var name = context.getArgument("name", String.class);
@@ -87,6 +91,8 @@ class WorldCreateCommand extends OptionCommand {
                 .seed(seed)
                 .structures(structures)
                 .generatorType(type)
+                .bonusChest(bonusChest)
+                .hardcore(hardcore)
                 .build();
 
         plugin.bundle().sendMessage(context.getSource().getSender(), "world.create",

--- a/src/main/java/net/thenextlvl/worlds/command/WorldCreateCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldCreateCommand.java
@@ -8,7 +8,6 @@ import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
-import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.worlds.WorldsPlugin;
@@ -18,6 +17,7 @@ import net.thenextlvl.worlds.api.generator.LevelStem;
 import net.thenextlvl.worlds.api.preset.Preset;
 import net.thenextlvl.worlds.command.argument.GeneratorArgument;
 import net.thenextlvl.worlds.command.argument.GeneratorTypeArgument;
+import net.thenextlvl.worlds.command.argument.KeyArgument;
 import net.thenextlvl.worlds.command.argument.LevelStemArgument;
 import net.thenextlvl.worlds.command.argument.SeedArgument;
 import net.thenextlvl.worlds.command.argument.WorldPresetArgument;
@@ -53,7 +53,7 @@ class WorldCreateCommand extends OptionCommand {
                 new Option("bonus-chest", BoolArgumentType.bool()),
                 new Option("hardcore", BoolArgumentType.bool()),
                 new Option("dimension", new LevelStemArgument(plugin)),
-                new Option("key", ArgumentTypes.key()),
+                new Option("key", new KeyArgument()),
                 new Option("seed", new SeedArgument()),
                 new Option("structures", BoolArgumentType.bool())
         ), null));
@@ -63,14 +63,6 @@ class WorldCreateCommand extends OptionCommand {
 
     @Override
     protected int execute(CommandContext<CommandSourceStack> context) {
-        // todo: custom parser
-        // var keyInput = context.getNodes().stream()
-        //         .filter(node -> node.getNode().getName().equals("key"))
-        //         .map(ParsedCommandNode::getRange)
-        //         .map(range -> range.get(context.getInput()))
-        //         .findAny();
-        // var key = keyInput.map(Key::key).orElseGet(() -> tryGetArgument(context, "key", Key.class));
-
         var generator = tryGetArgument(context, "generator", Generator.class);
         var key = tryGetArgument(context, "key", Key.class);
         var dimension = tryGetArgument(context, "dimension", LevelStem.class);

--- a/src/main/java/net/thenextlvl/worlds/command/WorldImportCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldImportCommand.java
@@ -7,7 +7,6 @@ import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
-import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.worlds.WorldsPlugin;
@@ -15,6 +14,7 @@ import net.thenextlvl.worlds.api.generator.Generator;
 import net.thenextlvl.worlds.api.generator.LevelStem;
 import net.thenextlvl.worlds.api.level.Level;
 import net.thenextlvl.worlds.command.argument.GeneratorArgument;
+import net.thenextlvl.worlds.command.argument.KeyArgument;
 import net.thenextlvl.worlds.command.argument.LevelStemArgument;
 import net.thenextlvl.worlds.command.suggestion.LevelSuggestionProvider;
 import org.bukkit.entity.Entity;
@@ -44,7 +44,7 @@ class WorldImportCommand extends OptionCommand {
                 .executes(this::execute);
 
         addOptions(command, false, Set.of(
-                new Option("key", ArgumentTypes.key()),
+                new Option("key", new KeyArgument()),
                 new Option("generator", new GeneratorArgument(plugin)),
                 new Option("name", StringArgumentType.string()),
                 new Option("dimension", new LevelStemArgument(plugin))

--- a/src/main/java/net/thenextlvl/worlds/command/WorldImportCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldImportCommand.java
@@ -43,12 +43,12 @@ class WorldImportCommand extends OptionCommand {
                 .suggests(new LevelSuggestionProvider<>(plugin, true))
                 .executes(this::execute);
 
-        addOptions(command, Set.of(
+        addOptions(command, false, Set.of(
                 new Option("key", ArgumentTypes.key()),
                 new Option("generator", new GeneratorArgument(plugin)),
                 new Option("name", StringArgumentType.string()),
-                new Option("type", "level-type", new LevelStemArgument(plugin))
-        ));
+                new Option("dimension", new LevelStemArgument(plugin))
+        ), null);
 
         return command;
     }
@@ -60,10 +60,10 @@ class WorldImportCommand extends OptionCommand {
         var displayName = tryGetArgument(context, "name", String.class);
         var generator = tryGetArgument(context, "generator", Generator.class);
         var key = tryGetArgument(context, "key", Key.class);
-        var levelStem = tryGetArgument(context, "level-type", LevelStem.class);
+        var dimension = tryGetArgument(context, "dimension", LevelStem.class);
 
         var build = plugin.levelView().read(Path.of(path)).map(level ->
-                level.key(key).name(displayName).generator(generator).levelStem(levelStem).build());
+                level.key(key).name(displayName).generator(generator).levelStem(dimension).build());
         var world = build.filter(level -> !level.isWorldKnown()).map(Level::createAsync).orElse(null);
 
         if (world == null) {

--- a/src/main/java/net/thenextlvl/worlds/command/WorldInfoCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldInfoCommand.java
@@ -61,7 +61,7 @@ class WorldInfoCommand {
                 Formatter.number("players", world.getPlayers().size()));
         plugin.bundle().sendMessage(sender, "world.info.type",
                 Placeholder.parsed("type", root.map(Level::getGeneratorType)
-                        .orElse(GeneratorType.NORMAL).presetName().asString()));
+                        .orElse(GeneratorType.NORMAL).name()));
         plugin.bundle().sendMessage(sender, "world.info.dimension",
                 Placeholder.parsed("dimension", root.map(level -> level.getLevelStem().dimensionType())
                         .orElse(DimensionType.OVERWORLD).key().asString()));

--- a/src/main/java/net/thenextlvl/worlds/command/WorldLinkRemoveCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldLinkRemoveCommand.java
@@ -10,6 +10,7 @@ import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.worlds.WorldsPlugin;
+import net.thenextlvl.worlds.command.argument.KeyArgument;
 import net.thenextlvl.worlds.command.suggestion.LinkSuggestionProvider;
 import org.bukkit.World;
 import org.jspecify.annotations.NullMarked;
@@ -25,7 +26,7 @@ class WorldLinkRemoveCommand {
     private static RequiredArgumentBuilder<CommandSourceStack, World> remove(WorldsPlugin plugin) {
         return Commands.argument("world", ArgumentTypes.world())
                 .suggests(new LinkSuggestionProvider<>(plugin, true))
-                .then(Commands.argument("destination", ArgumentTypes.key())
+                .then(Commands.argument("destination", new KeyArgument())
                         .suggests(new LinkSuggestionProvider.Linked<>(plugin))
                         .executes(context -> remove(plugin, context)));
     }

--- a/src/main/java/net/thenextlvl/worlds/command/argument/GeneratorTypeArgument.java
+++ b/src/main/java/net/thenextlvl/worlds/command/argument/GeneratorTypeArgument.java
@@ -1,8 +1,7 @@
 package net.thenextlvl.worlds.command.argument;
 
+import com.mojang.brigadier.arguments.StringArgumentType;
 import core.paper.command.WrappedArgumentType;
-import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
-import net.kyori.adventure.key.Key;
 import net.thenextlvl.worlds.WorldsPlugin;
 import net.thenextlvl.worlds.api.generator.GeneratorType;
 import net.thenextlvl.worlds.command.suggestion.DimensionSuggestionProvider;
@@ -11,17 +10,17 @@ import org.jspecify.annotations.NullMarked;
 import java.util.Map;
 
 @NullMarked
-public class GeneratorTypeArgument extends WrappedArgumentType<Key, GeneratorType> {
+public class GeneratorTypeArgument extends WrappedArgumentType<String, GeneratorType> {
     public GeneratorTypeArgument(WorldsPlugin plugin) {
-        super(ArgumentTypes.key(), (reader, type) -> GeneratorType.getByKey(type)
+        super(StringArgumentType.word(), (reader, type) -> GeneratorType.getByName(type)
                         .orElseThrow(() -> new IllegalArgumentException("Unknown dimension type")),
                 new DimensionSuggestionProvider(plugin, Map.of(
-                        GeneratorType.AMPLIFIED.key().asString(), "world.type.amplified",
-                        GeneratorType.DEBUG.key().asString(), "world.type.debug",
-                        GeneratorType.FLAT.key().asString(), "world.type.flat",
-                        GeneratorType.LARGE_BIOMES.key().asString(), "world.type.large_biomes",
-                        GeneratorType.NORMAL.key().asString(), "world.type.normal",
-                        GeneratorType.SINGLE_BIOME.key().asString(), "world.type.fixed"
+                        GeneratorType.AMPLIFIED.name(), "world.type.amplified",
+                        GeneratorType.DEBUG.name(), "world.type.debug",
+                        GeneratorType.FLAT.name(), "world.type.flat",
+                        GeneratorType.LARGE_BIOMES.name(), "world.type.large_biomes",
+                        GeneratorType.NORMAL.name(), "world.type.normal",
+                        GeneratorType.SINGLE_BIOME.name(), "world.type.fixed"
                 )));
     }
 }

--- a/src/main/java/net/thenextlvl/worlds/command/argument/KeyArgument.java
+++ b/src/main/java/net/thenextlvl/worlds/command/argument/KeyArgument.java
@@ -1,0 +1,56 @@
+package net.thenextlvl.worlds.command.argument;
+
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import core.paper.command.ComponentCommandExceptionType;
+import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
+import io.papermc.paper.command.brigadier.argument.CustomArgumentType;
+import net.kyori.adventure.key.InvalidKeyException;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class KeyArgument implements CustomArgumentType<Key, Key> {
+    public static final SimpleCommandExceptionType ERROR_INVALID = new ComponentCommandExceptionType(
+            Component.translatable("argument.id.invalid")
+    );
+
+    @Override
+    @SuppressWarnings("PatternValidation")
+    public Key parse(StringReader reader) throws CommandSyntaxException {
+        int cursor = reader.getCursor();
+
+        try {
+            var greedy = readGreedy(reader);
+            if (greedy.contains(":")) return Key.key(greedy);
+            else return Key.key("worlds", greedy);
+        } catch (InvalidKeyException e) {
+            reader.setCursor(cursor);
+            throw ERROR_INVALID.createWithContext(reader);
+        }
+    }
+
+    private static String readGreedy(StringReader reader) {
+        var cursor = reader.getCursor();
+
+        while (reader.canRead() && isAllowedInKey(reader.peek())) {
+            reader.skip();
+        }
+
+        return reader.getString().substring(cursor, reader.getCursor());
+    }
+
+    public static boolean isAllowedInKey(char character) {
+        // todo: replace with Key#allowedInKey
+        //  https://github.com/KyoriPowered/adventure/pull/1286
+        return Key.allowedInNamespace(character) || Key.allowedInValue(character) || character == ':';
+    }
+
+    @Override
+    public ArgumentType<Key> getNativeType() {
+        return ArgumentTypes.key();
+    }
+}

--- a/src/main/java/net/thenextlvl/worlds/command/argument/LevelStemArgument.java
+++ b/src/main/java/net/thenextlvl/worlds/command/argument/LevelStemArgument.java
@@ -1,8 +1,7 @@
 package net.thenextlvl.worlds.command.argument;
 
+import com.mojang.brigadier.arguments.StringArgumentType;
 import core.paper.command.WrappedArgumentType;
-import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
-import net.kyori.adventure.key.Key;
 import net.thenextlvl.worlds.WorldsPlugin;
 import net.thenextlvl.worlds.api.generator.LevelStem;
 import net.thenextlvl.worlds.command.suggestion.DimensionSuggestionProvider;
@@ -11,17 +10,17 @@ import org.jspecify.annotations.NullMarked;
 import java.util.Map;
 
 @NullMarked
-public class LevelStemArgument extends WrappedArgumentType<Key, LevelStem> {
+public class LevelStemArgument extends WrappedArgumentType<String, LevelStem> {
     public LevelStemArgument(WorldsPlugin plugin) {
-        super(ArgumentTypes.key(), (reader, type) -> switch (type.asString()) {
-            case "minecraft:overworld" -> LevelStem.OVERWORLD;
-            case "minecraft:nether" -> LevelStem.NETHER;
-            case "minecraft:end" -> LevelStem.END;
+        super(StringArgumentType.word(), (reader, type) -> switch (type) {
+            case "normal", "overworld" -> LevelStem.OVERWORLD;
+            case "nether" -> LevelStem.NETHER;
+            case "end" -> LevelStem.END;
             default -> throw new IllegalArgumentException("Custom dimensions are not yet supported");
         }, new DimensionSuggestionProvider(plugin, Map.of(
-                "minecraft:overworld", "environment.normal",
-                "minecraft:nether", "environment.nether",
-                "minecraft:end", "environment.end"
+                "normal", "environment.normal",
+                "nether", "environment.nether",
+                "end", "environment.end"
         )));
     }
 }


### PR DESCRIPTION
- Added `bonus-chest` and `hardcore` option
- Replaced `key` argument with a `name` argument, moved key argument to separate option
- Made argument order lenient
- Converted `type` and `dimension` arguments to words for easier use
  - renamed "overworld" type and dimension to "normal"

<img width="1485" height="246" alt="image" src="https://github.com/user-attachments/assets/8055bb8d-7966-4f89-97f5-6b15ef100c2b" />
