### PR TITLE
Fixed dimension type detection logic

### DIFF
--- a/api/src/main/java/net/thenextlvl/worlds/api/generator/LevelStem.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/generator/LevelStem.java
@@ -1,6 +1,9 @@
 package net.thenextlvl.worlds.api.generator;
 
+import net.kyori.adventure.key.Key;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @since 3.0.0
@@ -10,4 +13,12 @@ public record LevelStem(DimensionType dimensionType) {
     public static final LevelStem OVERWORLD = new LevelStem(DimensionType.OVERWORLD);
     public static final LevelStem NETHER = new LevelStem(DimensionType.THE_NETHER);
     public static final LevelStem END = new LevelStem(DimensionType.THE_END);
+
+    @Contract(pure = true)
+    public static @Nullable LevelStem of(Key key) {
+        if (key.equals(DimensionType.OVERWORLD.key())) return OVERWORLD;
+        if (key.equals(DimensionType.THE_NETHER.key())) return NETHER;
+        if (key.equals(DimensionType.THE_END.key())) return END;
+        return null;
+    }
 }

--- a/src/main/java/net/thenextlvl/worlds/level/LevelData.java
+++ b/src/main/java/net/thenextlvl/worlds/level/LevelData.java
@@ -421,11 +421,12 @@ public abstract class LevelData implements Level {
         var worldKnown = pdc.map(LevelData::isKnown).orElse(false);
         var key = pdc.flatMap(tag -> tag.optional("worlds:world_key")
                 .map(Tag::getAsString).map(Key::key)).orElseGet(() -> Key.key("worlds", createKey(name)));
+        var levelStem = pdc.flatMap(tag -> tag.optional("worlds:dimension").map(Tag::getAsString))
+                .map(Key::key).map(LevelStem::of).orElseGet(() -> getLevelStem(plugin, level));
         var enabled = pdc.flatMap(tag -> tag.optional("worlds:enabled").map(Tag::getAsBoolean)
                 .map(TriState::byBoolean)).orElse(TriState.NOT_SET);
         var chunkGenerator = pdc.flatMap(tag -> tag.optional("worlds:generator").map(Tag::getAsString)).map(serialized ->
                 Generator.of(plugin, serialized)).orElse(null);
-        var levelStem = getLevelStem(plugin, level);
         var settings = data.flatMap(tag -> tag.<CompoundTag>optional("WorldGenSettings"));
         var dimensions = settings.flatMap(tag -> tag.<CompoundTag>optional("dimensions"));
         var dimension = dimensions.flatMap(tag -> tag.<CompoundTag>optional(levelStem.dimensionType().key().asString()));
@@ -530,7 +531,10 @@ public abstract class LevelData implements Level {
     }
 
     private static boolean isKnown(CompoundTag tag) {
-        return tag.containsKey("worlds:world_key") || tag.containsKey("worlds:enabled") || tag.containsKey("worlds:generator");
+        return tag.containsKey("worlds:dimension")
+               || tag.containsKey("worlds:enabled")
+               || tag.containsKey("worlds:generator")
+               || tag.containsKey("worlds:world_key");
     }
 
     public static @Subst("pattern") String createKey(String name) {

--- a/src/main/java/net/thenextlvl/worlds/level/PaperLevel.java
+++ b/src/main/java/net/thenextlvl/worlds/level/PaperLevel.java
@@ -264,16 +264,18 @@ class PaperLevel extends LevelData {
             io.papermc.paper.threadedregions.RegionizedServer.getInstance().addWorld(serverLevel);
         FeatureHooks.tickEntityManager(serverLevel);
 
-        persistWorld(serverLevel.getWorld(), enabled.toBooleanOrElse(true));
+        persistWorld(serverLevel.getWorld(), levelStem, enabled.toBooleanOrElse(true));
         if (generator != null) persistGenerator(serverLevel.getWorld(), generator);
 
         new WorldLoadEvent(serverLevel.getWorld()).callEvent();
         return future;
     }
 
-    public void persistWorld(World world, boolean enabled) {
+    public void persistWorld(World world, net.thenextlvl.worlds.api.generator.LevelStem dimension, boolean enabled) {
         var worldKey = new NamespacedKey("worlds", "world_key");
+        var dimensionKey = new NamespacedKey("worlds", "dimension");
         world.getPersistentDataContainer().set(worldKey, STRING, world.key().asString());
+        world.getPersistentDataContainer().set(dimensionKey, STRING, dimension.dimensionType().key().asString());
         plugin.levelView().setEnabled(world, enabled);
     }
 


### PR DESCRIPTION
Resolved an issue where non-overworld worlds were incorrectly identified as "OVERWORLD" due to the presence of the overworld region folder. Updated `LevelStem` to include `of(Key)` method for accurate dimension mapping. Enhanced persistence to store and retrieve dimension type consistently.