### PR TITLE
Fixed OverlappingFileLockException when unloading and load or regenerating worlds on Folia

### DIFF
--- a/src/main/java/net/thenextlvl/worlds/view/FoliaLevelView.java
+++ b/src/main/java/net/thenextlvl/worlds/view/FoliaLevelView.java
@@ -90,7 +90,7 @@ public class FoliaLevelView extends PaperLevelView {
                 });
 
                 return closingFuture;
-            }).thenApply(ignored -> {
+            }).thenCompose(self -> self).thenApply(ignored -> {
                 try {
                     var field = server.getClass().getDeclaredField("worlds");
                     field.trySetAccessible();


### PR DESCRIPTION
Fixes #222  

Replaced `.thenApply` with `.thenCompose` for better sequential execution in `FoliaLevelView`.