### PR TITLE
Improved `/world clone` command

### DIFF
--- a/src/main/java/net/thenextlvl/worlds/command/WorldCloneCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldCloneCommand.java
@@ -1,6 +1,8 @@
 package net.thenextlvl.worlds.command;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
@@ -9,35 +11,56 @@ import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.worlds.WorldsPlugin;
+import net.thenextlvl.worlds.command.argument.KeyArgument;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
-import static net.thenextlvl.worlds.command.WorldCommand.keyArgument;
+import java.util.Set;
+
 import static net.thenextlvl.worlds.command.WorldCommand.worldArgument;
 import static org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND;
 
 @NullMarked
-class WorldCloneCommand {
+class WorldCloneCommand extends OptionCommand {
+
+    private WorldCloneCommand(WorldsPlugin plugin) {
+        super(plugin);
+    }
+
     public static ArgumentBuilder<CommandSourceStack, ?> create(WorldsPlugin plugin) {
+        var command = new WorldCloneCommand(plugin);
         return Commands.literal("clone")
                 .requires(source -> source.getSender().hasPermission("worlds.command.clone"))
-                .then(clone(plugin));
+                .then(command.createCommand());
     }
 
-    private static RequiredArgumentBuilder<CommandSourceStack, World> clone(WorldsPlugin plugin) {
-        return worldArgument(plugin).then(keyArgument().then(Commands.literal("template")
-                        .executes(context -> clone(context, false, plugin)))
-                .executes(context -> clone(context, true, plugin)));
+    private RequiredArgumentBuilder<CommandSourceStack, ?> createCommand() {
+        var world = worldArgument(plugin);
+
+        addOptions(world, false, Set.of(
+                new Option("full", BoolArgumentType.bool()),
+                new Option("key", new KeyArgument()),
+                new Option("name", StringArgumentType.string())
+        ), null);
+
+        return world.executes(this::execute);
     }
 
-    private static int clone(CommandContext<CommandSourceStack> context, boolean full, WorldsPlugin plugin) {
-        var sender = context.getSource().getSender();
+    @Override
+    protected int execute(CommandContext<CommandSourceStack> context) {
         var world = context.getArgument("world", World.class);
+
+        var full = tryGetArgument(context, "full", Boolean.class).orElse(true);
+
+        var sender = context.getSource().getSender();
         var placeholder = Placeholder.parsed("world", world.getName());
-        var key = context.getArgument("key", Key.class);
+
         plugin.bundle().sendMessage(sender, "world.clone", placeholder);
-        plugin.levelView().cloneAsync(world, builder -> builder.key(key), full).thenAccept(clone -> {
+        plugin.levelView().cloneAsync(world, builder -> {
+            tryGetArgument(context, "name", String.class).ifPresent(builder::name);
+            tryGetArgument(context, "key", Key.class).ifPresent(builder::key);
+        }, full).thenAccept(clone -> {
             if (sender instanceof Player player) player.teleportAsync(clone.getSpawnLocation(), COMMAND);
             plugin.bundle().sendMessage(sender, "world.clone.success", placeholder);
         }).exceptionally(throwable -> {


### PR DESCRIPTION
Added new options to `/world clone` command:
- `full`: whether the clone should include world and entity data
- `key`: the key for the new world
- `name`: the name for the new world

Cloning a world no longer requires a name or key to be defined and now automatically creates one if undefined