### PR TITLE
Enhance world regeneration with builder support

### DIFF
--- a/api/src/main/java/net/thenextlvl/worlds/api/view/LevelView.java
+++ b/api/src/main/java/net/thenextlvl/worlds/api/view/LevelView.java
@@ -479,10 +479,30 @@ public interface LevelView {
      *                 if false, the regeneration will be attempted immediately
      * @return a {@code CompletableFuture} completing with a
      * {@code DeletionResult} indicating the outcome of the regeneration process.
+     * @see #regenerateAsync(World, boolean, Consumer)
      * @since 3.2.0
      */
     @Contract(mutates = "io,param1")
-    CompletableFuture<DeletionResult> regenerateAsync(World world, boolean schedule);
+    default CompletableFuture<DeletionResult> regenerateAsync(World world, boolean schedule) {
+        return regenerateAsync(world, schedule, builder -> {
+        });
+    }
+
+    /**
+     * Regenerates the specified world, either immediately or scheduled, based on the provided parameters.
+     * <p>
+     * The builder consumer is only applied when the regeneration is not scheduled.
+     *
+     * @param world    the world to be regenerated
+     * @param schedule if true, the regeneration will be scheduled for later execution;
+     *                 if false, the regeneration will be attempted immediately
+     * @param builder  a consumer that modifies the {@link Level.Builder} properties of the regenerated world
+     * @return a {@code CompletableFuture} completing with a
+     * {@code DeletionResult} indicating the outcome of the regeneration process.
+     * @since 3.10.0
+     */
+    @Contract(mutates = "io,param1")
+    CompletableFuture<DeletionResult> regenerateAsync(World world, boolean schedule, Consumer<Level.Builder> builder);
 
     /**
      * Cancels the regeneration process for the specified world, if scheduled.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ tasks.compileJava {
 }
 
 group = "net.thenextlvl.worlds"
-version = "3.9.0"
+version = "3.10.0"
 
 repositories {
     mavenCentral()

--- a/src/main/java/net/thenextlvl/worlds/command/WorldRegenerateCommand.java
+++ b/src/main/java/net/thenextlvl/worlds/command/WorldRegenerateCommand.java
@@ -31,7 +31,7 @@ final class WorldRegenerateCommand extends SimpleCommand {
     private RequiredArgumentBuilder<CommandSourceStack, World> regenerate() {
         return worldArgument(plugin)
                 .then(Commands.argument("flags", new CommandFlagsArgument(
-                        Set.of("--confirm", "--schedule")
+                        Set.of("--confirm", "--schedule", "--seed")
                 )).executes(this))
                 .executes(this::confirmationNeeded);
     }
@@ -52,7 +52,9 @@ final class WorldRegenerateCommand extends SimpleCommand {
         var schedule = flags.contains("--schedule");
         if (!schedule) plugin.bundle().sendMessage(context.getSource().getSender(), "world.regenerate",
                 Placeholder.parsed("world", world.getName()));
-        plugin.levelView().regenerateAsync(world, schedule).thenAccept(result -> {
+        plugin.levelView().regenerateAsync(world, schedule, builder -> {
+            if (flags.contains("--seed")) builder.seed(null);
+        }).thenAccept(result -> {
             var message = switch (result) {
                 case SUCCESS -> "world.regenerate.success";
                 case SCHEDULED -> "world.regenerate.scheduled";

--- a/src/main/java/net/thenextlvl/worlds/level/PaperLevel.java
+++ b/src/main/java/net/thenextlvl/worlds/level/PaperLevel.java
@@ -128,6 +128,19 @@ final class PaperLevel extends LevelData {
             );
             primaryLevelData = (PrimaryLevelData) levelDataAndDimensions.worldData();
             registryAccess = levelDataAndDimensions.dimensions().dimensionsRegistryAccess();
+
+            /// Worlds start - override options
+            try {
+                var worldOptions = new WorldOptions(seed, structures, bonusChest);
+                var optionsField = PrimaryLevelData.class.getDeclaredField("worldOptions");
+                var accessible = optionsField.canAccess(primaryLevelData);
+                if (!accessible) optionsField.trySetAccessible();
+                optionsField.set(primaryLevelData, worldOptions);
+                if (!accessible) optionsField.setAccessible(false);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                plugin.getComponentLogger().warn("Failed to override world options", e);
+            }
+            /// Worlds end
         } else {
             LevelSettings levelSettings;
             WorldOptions worldOptions = new WorldOptions(seed, structures, bonusChest);


### PR DESCRIPTION
- Added `Consumer<Level.Builder>` parameter to regenerateAsync
- Updated LevelView interface with new method signature
- Modified PaperLevel to apply world options during creation
- Adjusted command to handle seed override during regeneration