### PR TITLE
Reintroduce end portal gravity block duping

### DIFF
--- a/src/main/java/net/thenextlvl/worlds/listener/PortalListener.java
+++ b/src/main/java/net/thenextlvl/worlds/listener/PortalListener.java
@@ -2,6 +2,7 @@ package net.thenextlvl.worlds.listener;
 
 import io.papermc.paper.event.entity.EntityPortalReadyEvent;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.levelgen.feature.EndPlatformFeature;
 import net.thenextlvl.worlds.WorldsPlugin;
 import net.thenextlvl.worlds.model.PortalCooldown;
@@ -39,6 +40,11 @@ public class PortalListener implements Listener {
                 .ifPresentOrElse(event::setTargetWorld, () -> event.setTargetWorld(null));
     }
 
+    /**
+     * @see net.minecraft.world.level.block.EndPortalBlock#getPortalDestination(ServerLevel, net.minecraft.world.entity.Entity, BlockPos)
+     * @see net.minecraft.world.entity.Entity#handlePortal()
+     */
+    @SuppressWarnings("JavadocReference")
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onEntityPortalEnter(EntityPortalEnterEvent event) {
         if (!event.getPortalType().equals(PortalType.ENDER)) return;
@@ -52,6 +58,11 @@ public class PortalListener implements Listener {
 
         var targetWorld = readyEvent.getTargetWorld();
         if (targetWorld == null) return;
+
+        if (plugin.levelView().isOverworld(event.getEntity().getWorld()) && plugin.levelView().isEnd(targetWorld)) {
+            event.setCancelled(false); // Don't handle overworld to end teleportation to allow gravity block duping
+            return;
+        }
 
         if (targetWorld.getEnvironment().equals(World.Environment.THE_END)) {
             var spawn = new Location(targetWorld, 100.5, 49, 0.5, 90, 0);

--- a/src/main/java/net/thenextlvl/worlds/view/PaperLevelView.java
+++ b/src/main/java/net/thenextlvl/worlds/view/PaperLevelView.java
@@ -112,6 +112,10 @@ public class PaperLevelView implements LevelView {
         return world.key().equals(OVERWORLD);
     }
 
+    public boolean isEnd(World world) {
+        return world.key().equals(END);
+    }
+
     private @Nullable Path getLevelDataPath(Path level) {
         return Optional.ofNullable(getFile(level, "level.dat"))
                 .orElseGet(() -> getFile(level, "level.dat_old"));


### PR DESCRIPTION
Fixes #226 

Paper doesn't allow for block duplication inside non-default worlds, so this "fix" only applies to the vanilla overworld and the end.


---

For the people who care

Another possible solution is this, but the restrictions can't be _easily_ bypassed, without rewriting the ticking logic which is out of scope for this plugin:
```java
var spawn = new Location(targetWorld, 100.5, 50, 0.5, 90, 0);
generateEndPlatform(targetWorld, event.getEntity());
falling.getHandle().setAsInsidePortal((level, entity, pos) -> new TeleportTransition(
        ((CraftWorld) spawn.getWorld()).getHandle(),
        CraftLocation.toVec3(spawn),
        Vec3.ZERO, spawn.getYaw(), spawn.getPitch(),
        Relative.union(Relative.DELTA, Set.of(Relative.X_ROT)),
        TeleportTransition.PLAY_PORTAL_SOUND.then(TeleportTransition.PLACE_PORTAL_TICKET),
        END_PORTAL
), falling.getHandle().blockPosition());
```