### PR TITLE
Added migration support

### DIFF
--- a/api/src/main/java/net/thenextlvl/worlds/Level.java
+++ b/api/src/main/java/net/thenextlvl/worlds/Level.java
@@ -110,6 +110,28 @@ public sealed interface Level extends Keyed permits SimpleLevel {
     Optional<Generator> getGenerator();
 
     /**
+     * Returns whether existing level data should be ignored.
+     *
+     * @return {@code true} if level data should be ignored, otherwise {@code false}
+     * @since 4.0.1
+     */
+    @ApiStatus.Experimental
+    @Contract(pure = true)
+    boolean ignoreLevelData();
+
+    /**
+     * Returns the legacy Bukkit world name used during migration.
+     * <p>
+     * This value is only and exclusively used for legacy world migration. It must be the
+     * original legacy Bukkit name of the world directory, not a derived key or path.
+     *
+     * @return the legacy Bukkit world name, or empty
+     * @since 4.0.1
+     */
+    @Contract(pure = true)
+    Optional<String> legacyName();
+
+    /**
      * Returns the Bukkit chunk generator.
      *
      * @return the chunk generator, or empty
@@ -392,6 +414,49 @@ public sealed interface Level extends Keyed permits SimpleLevel {
          */
         @Contract(mutates = "this")
         Builder generator(@Nullable Generator generator);
+
+        /**
+         * Returns whether level data should be ignored.
+         *
+         * @return whether level data should be ignored
+         * @since 4.0.1
+         */
+        @ApiStatus.Experimental
+        @Contract(pure = true)
+        Optional<Boolean> ignoreLevelData();
+
+        /**
+         * Sets whether existing level data should be ignored.
+         *
+         * @param ignoreLevelData whether level data should be ignored, or {@code null} for {@code false}
+         * @return this builder
+         * @since 4.0.1
+         */
+        @ApiStatus.Experimental
+        @Contract(mutates = "this")
+        Builder ignoreLevelData(@Nullable Boolean ignoreLevelData);
+
+        /**
+         * Returns the legacy Bukkit world name used during migration.
+         *
+         * @return the legacy bukkit world name, or empty
+         * @since 4.0.1
+         */
+        @Contract(pure = true)
+        Optional<String> legacyName();
+
+        /**
+         * Sets the legacy Bukkit world name used during migration.
+         * <p>
+         * This is only and exclusively for legacy world migration. It must be the original
+         * legacy Bukkit name of the world directory, not a derived key or path.
+         *
+         * @param name the legacy Bukkit world name, or {@code null}
+         * @return this builder
+         * @since 4.0.1
+         */
+        @Contract(mutates = "this")
+        Builder legacyName(@Nullable String name);
 
         /**
          * Builds a level from the configured values.

--- a/api/src/main/java/net/thenextlvl/worlds/Level.java
+++ b/api/src/main/java/net/thenextlvl/worlds/Level.java
@@ -113,7 +113,7 @@ public sealed interface Level extends Keyed permits SimpleLevel {
      * Returns whether existing level data should be ignored.
      *
      * @return {@code true} if level data should be ignored, otherwise {@code false}
-     * @since 4.0.1
+     * @since 4.1.0
      */
     @ApiStatus.Experimental
     @Contract(pure = true)
@@ -126,7 +126,7 @@ public sealed interface Level extends Keyed permits SimpleLevel {
      * original legacy Bukkit name of the world directory, not a derived key or path.
      *
      * @return the legacy Bukkit world name, or empty
-     * @since 4.0.1
+     * @since 4.1.0
      */
     @Contract(pure = true)
     Optional<String> legacyName();
@@ -419,7 +419,7 @@ public sealed interface Level extends Keyed permits SimpleLevel {
          * Returns whether level data should be ignored.
          *
          * @return whether level data should be ignored
-         * @since 4.0.1
+         * @since 4.1.0
          */
         @ApiStatus.Experimental
         @Contract(pure = true)
@@ -430,7 +430,7 @@ public sealed interface Level extends Keyed permits SimpleLevel {
          *
          * @param ignoreLevelData whether level data should be ignored, or {@code null} for {@code false}
          * @return this builder
-         * @since 4.0.1
+         * @since 4.1.0
          */
         @ApiStatus.Experimental
         @Contract(mutates = "this")
@@ -440,7 +440,7 @@ public sealed interface Level extends Keyed permits SimpleLevel {
          * Returns the legacy Bukkit world name used during migration.
          *
          * @return the legacy bukkit world name, or empty
-         * @since 4.0.1
+         * @since 4.1.0
          */
         @Contract(pure = true)
         Optional<String> legacyName();
@@ -453,7 +453,7 @@ public sealed interface Level extends Keyed permits SimpleLevel {
          *
          * @param name the legacy Bukkit world name, or {@code null}
          * @return this builder
-         * @since 4.0.1
+         * @since 4.1.0
          */
         @Contract(mutates = "this")
         Builder legacyName(@Nullable String name);

--- a/api/src/main/java/net/thenextlvl/worlds/SimpleLevel.java
+++ b/api/src/main/java/net/thenextlvl/worlds/SimpleLevel.java
@@ -26,6 +26,8 @@ final class SimpleLevel implements Level {
     private final @Nullable ChunkGenerator chunkGenerator;
 
     private final @Nullable Generator generator;
+    private final @Nullable String legacyName;
+    private final boolean ignoreLevelData;
 
     private final @Nullable Position spawnPositionOverride;
     private final @Nullable Rotation spawnRotationOverride;
@@ -54,6 +56,8 @@ final class SimpleLevel implements Level {
         this.resetSpawnPosition = builder.resetSpawnPosition().orElse(false);
 
         this.generator = builder.generator;
+        this.ignoreLevelData = builder.ignoreLevelData().orElse(false);
+        this.legacyName = builder.legacyName().orElse(null);
 
         this.biomeProvider = builder.generator().flatMap(generator -> generator.biomeProvider(getName())).orElse(null);
         this.chunkGenerator = builder.generator().flatMap(generator -> generator.generator(getName())).orElse(null);
@@ -102,6 +106,16 @@ final class SimpleLevel implements Level {
     }
 
     @Override
+    public boolean ignoreLevelData() {
+        return ignoreLevelData;
+    }
+
+    @Override
+    public Optional<String> legacyName() {
+        return Optional.ofNullable(legacyName);
+    }
+
+    @Override
     public Optional<ChunkGenerator> getChunkGenerator() {
         return Optional.ofNullable(chunkGenerator);
     }
@@ -137,8 +151,10 @@ final class SimpleLevel implements Level {
                 .bonusChest(bonusChest)
                 .dimension(dimension)
                 .generator(generator)
+                .ignoreLevelData(ignoreLevelData)
                 .generatorType(generatorType)
                 .hardcore(hardcore)
+                .legacyName(legacyName)
                 .seed(seed)
                 .structures(structures);
     }
@@ -163,6 +179,7 @@ final class SimpleLevel implements Level {
     static final class Builder implements Level.Builder {
         private @Nullable Boolean bonusChest;
         private @Nullable Boolean hardcore;
+        private @Nullable Boolean ignoreLevelData;
         private @Nullable Boolean resetSpawnPosition;
         private @Nullable Boolean structures;
         private @Nullable Dimension dimension;
@@ -171,6 +188,7 @@ final class SimpleLevel implements Level {
         private @Nullable Long seed;
         private @Nullable Position spawnPositionOverride;
         private @Nullable Rotation spawnRotationOverride;
+        private @Nullable String legacyName;
         private Key key;
 
         public Builder(final Key key) {
@@ -292,6 +310,28 @@ final class SimpleLevel implements Level {
         @Override
         public Level.Builder generator(@Nullable final Generator generator) {
             this.generator = generator;
+            return this;
+        }
+
+        @Override
+        public Optional<Boolean> ignoreLevelData() {
+            return Optional.ofNullable(ignoreLevelData);
+        }
+
+        @Override
+        public Level.Builder ignoreLevelData(@Nullable final Boolean ignoreLevelData) {
+            this.ignoreLevelData = ignoreLevelData;
+            return this;
+        }
+
+        @Override
+        public Optional<String> legacyName() {
+            return Optional.ofNullable(legacyName);
+        }
+
+        @Override
+        public Level.Builder legacyName(@Nullable final String name) {
+            this.legacyName = name;
             return this;
         }
 

--- a/api/src/main/java/net/thenextlvl/worlds/WorldRegistry.java
+++ b/api/src/main/java/net/thenextlvl/worlds/WorldRegistry.java
@@ -93,10 +93,11 @@ public interface WorldRegistry {
      * @param dimension the world dimension
      * @param enabled   whether the world is enabled
      * @param generator the world generator, or {@code null}
+     * @return whether the world has been registered
      * @since 4.0.0
      */
     @Contract(mutates = "this,io")
-    void registerIfAbsent(final Key key, final Dimension dimension, final boolean enabled, @Nullable final Generator generator);
+    boolean registerIfAbsent(final Key key, final Dimension dimension, final boolean enabled, @Nullable final Generator generator);
 
     /**
      * Registers a level.

--- a/api/src/main/java/net/thenextlvl/worlds/generator/SimpleGenerator.java
+++ b/api/src/main/java/net/thenextlvl/worlds/generator/SimpleGenerator.java
@@ -51,11 +51,11 @@ final class SimpleGenerator implements Generator {
         final var generator = WorldsAccess.access().getServer().getPluginManager().getPlugin(plugin);
 
         if (generator == null)
-            throw new GeneratorException(plugin, id, "Plugin not found");
+            throw new GeneratorException(plugin, id, "Plugin \"" + plugin + "\" not found");
         if (!generator.isEnabled())
-            throw new GeneratorException(plugin, id, "Plugin is not enabled, is it 'load: STARTUP'?");
+            throw new GeneratorException(plugin, id, "Plugin \"" + plugin + "\" is not enabled, is it 'load: STARTUP'?");
         if (!GeneratorView.view().hasGenerator(generator))
-            throw new GeneratorException(plugin, id, "Plugin has no generator");
+            throw new GeneratorException(plugin, id, "Plugin \"" + plugin + "\" has no generator");
 
         return new SimpleGenerator(generator, id);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 gameVersions=26.1.2
 loaders=paper,folia
-version=4.0.0
+version=4.1.0

--- a/plugin/src/main/java/net/thenextlvl/worlds/LegacyWorldRegistry.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/LegacyWorldRegistry.java
@@ -1,0 +1,99 @@
+package net.thenextlvl.worlds;
+
+import net.kyori.adventure.key.Key;
+import net.thenextlvl.nbt.NBTInputStream;
+import net.thenextlvl.nbt.tag.Tag;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+@NullMarked
+public final class LegacyWorldRegistry {
+    private final Map<Path, LegacyWorldData> worlds = new ConcurrentHashMap<>();
+    private final WorldsPlugin plugin;
+
+    public LegacyWorldRegistry(final WorldsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public Stream<Path> listPaths(final Path path) {
+        try (final var files = Files.list(path)) {
+            return files.filter(p -> read(p).isPresent()).toList().stream();
+        } catch (final IOException e) {
+            return Stream.empty();
+        }
+    }
+
+    public Optional<LegacyWorldData> read(final Path path) {
+        worlds.keySet().removeIf(p -> !Files.isDirectory(p));
+        final var normalized = path.toAbsolutePath().normalize();
+        if (isLegacyWorld(normalized)) {
+            final var legacyWorldData = worlds.computeIfAbsent(normalized, this::readLegacyWorld);
+            return Optional.ofNullable(legacyWorldData);
+        }
+        worlds.remove(normalized);
+        return Optional.empty();
+    }
+
+    private boolean isLegacyWorld(final Path path) {
+        return Files.isRegularFile(path.resolve("level.dat"))
+                || Files.isRegularFile(path.resolve("level.dat_old"));
+    }
+
+    private @Nullable Path resolveLevelDat(final Path path) {
+        final var levelDat = path.resolve("level.dat");
+        if (Files.isRegularFile(levelDat)) return levelDat;
+        final var levelDatOld = path.resolve("level.dat_old");
+        if (Files.isRegularFile(levelDatOld)) return levelDatOld;
+        return null;
+    }
+
+    private @Nullable LegacyWorldData readLegacyWorld(final Path path) {
+        final var data = resolveLevelDat(path);
+        if (data == null) return null;
+        try (final var input = NBTInputStream.create(data)) {
+            final var pdc = input.readTag()
+                    .optional("Data").map(Tag::getAsCompound)
+                    .flatMap(tag -> tag.optional("BukkitValues").map(Tag::getAsCompound))
+                    .orElse(null);
+            if (pdc == null) return null;
+
+            final var enabled = pdc.optional("worlds:enabled").map(Tag::getAsBoolean).orElse(null);
+            if (enabled == null) return null;
+
+            final var key = pdc.optional("worlds:world_key").map(Tag::getAsString).map(Key::key).orElse(null);
+            if (key == null) return null;
+
+            final var dimension = pdc.optional("worlds:dimension")
+                    .map(Tag::getAsString)
+                    .map(this::dimension)
+                    .orElse(Dimension.OVERWORLD);
+            final var generator = pdc.optional("worlds:generator")
+                    .map(Tag::getAsString)
+                    .orElse(null);
+            return new LegacyWorldData(key, dimension, enabled, generator);
+        } catch (final Exception e) {
+            plugin.getComponentLogger().warn("Failed to read legacy world data from {}", path, e);
+            return null;
+        }
+    }
+
+    private @Nullable Dimension dimension(final String key) {
+        return switch (key) {
+            case "minecraft:overworld" -> Dimension.OVERWORLD;
+            case "minecraft:the_end" -> Dimension.THE_END;
+            case "minecraft:the_nether" -> Dimension.THE_NETHER;
+            default -> null;
+        };
+    }
+
+    public record LegacyWorldData(Key key, Dimension dimension, boolean enabled, @Nullable String generator) {
+    }
+}

--- a/plugin/src/main/java/net/thenextlvl/worlds/SimpleWorldRegistry.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/SimpleWorldRegistry.java
@@ -65,9 +65,11 @@ public final class SimpleWorldRegistry implements WorldRegistry {
     }
 
     @Override
-    public void registerIfAbsent(final Key key, final Dimension dimension, final boolean enabled, @Nullable final Generator generator) {
+    public boolean registerIfAbsent(final Key key, final Dimension dimension, final boolean enabled, @Nullable final Generator generator) {
         final var entry = entries.putIfAbsent(key, new Entry(dimension, enabled, generator));
-        if (entry == null) save();
+        if (entry != null) return false;
+        save();
+        return true;
     }
 
     @Override

--- a/plugin/src/main/java/net/thenextlvl/worlds/WorldsPlugin.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/WorldsPlugin.java
@@ -68,6 +68,7 @@ public final class WorldsPlugin extends JavaPlugin implements PluginAccess, Worl
     private final PaperLevelView levelView = versionHandler.foliaSupport()
             .<PaperLevelView>map(support -> new FoliaLevelView(this, support))
             .orElseGet(() -> new PaperLevelView(this));
+    private final LegacyWorldRegistry legacyWorldRegistry = new LegacyWorldRegistry(this);
     private final SimpleWorldRegistry worldRegistry = new SimpleWorldRegistry(this);
     private final SimpleOperationScheduler worldOperationScheduler = new SimpleOperationScheduler(this);
 
@@ -156,6 +157,10 @@ public final class WorldsPlugin extends JavaPlugin implements PluginAccess, Worl
 
     public PaperLevelView levelView() {
         return levelView;
+    }
+
+    public LegacyWorldRegistry legacyWorldRegistry() {
+        return legacyWorldRegistry;
     }
 
     private void createPresetsFolder() {

--- a/plugin/src/main/java/net/thenextlvl/worlds/command/WorldImportCommand.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/command/WorldImportCommand.java
@@ -1,5 +1,7 @@
 package net.thenextlvl.worlds.command;
 
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
@@ -14,16 +16,20 @@ import net.thenextlvl.worlds.command.argument.CommandOptionsArgument;
 import net.thenextlvl.worlds.command.argument.DimensionArgumentType;
 import net.thenextlvl.worlds.command.argument.GeneratorArgument;
 import net.thenextlvl.worlds.command.argument.KeyArgument;
-import net.thenextlvl.worlds.command.argument.WorldPresetArgument;
 import net.thenextlvl.worlds.command.brigadier.SimpleCommand;
-import net.thenextlvl.worlds.command.suggestion.WorldImportSuggestionProvider;
+import net.thenextlvl.worlds.command.suggestion.WorldKeyImportSuggestionProvider;
+import net.thenextlvl.worlds.command.suggestion.WorldPathImportSuggestionProvider;
+import net.thenextlvl.worlds.command.suggestion.WorldPathKeyImportSuggestionProvider;
 import net.thenextlvl.worlds.generator.Generator;
 import net.thenextlvl.worlds.generator.GeneratorType;
 import net.thenextlvl.worlds.preset.Preset;
 import org.bukkit.entity.Entity;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-import java.util.Map;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
 
 import static org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.COMMAND;
 
@@ -36,17 +42,23 @@ final class WorldImportCommand extends SimpleCommand {
     public static ArgumentBuilder<CommandSourceStack, ?> create(final WorldsPlugin plugin) {
         final var command = new WorldImportCommand(plugin);
 
-        final var options = Commands.argument("options", new CommandOptionsArgument(Map.of(
-                "dimension", new DimensionArgumentType(plugin),
-                "generator", new GeneratorArgument(plugin),
-                "preset", new WorldPresetArgument(plugin)
-        ))).executes(command);
+        final var key = Commands.argument("key", new KeyArgument())
+                .suggests(new WorldKeyImportSuggestionProvider(plugin));
+        final var path = Commands.argument("path", StringArgumentType.string())
+                .suggests(new WorldPathImportSuggestionProvider(plugin));
+        final var pathKey = Commands.argument("key", new KeyArgument())
+                .suggests(new WorldPathKeyImportSuggestionProvider(plugin));
+        return command.create()
+                .then(key.then(command.options()).executes(command))
+                .then(path.then(pathKey.then(command.options()).executes(command)));
+    }
 
-        final var key = Commands.argument("key", new KeyArgument());
-        return command.create().then(key
-                .suggests(new WorldImportSuggestionProvider(plugin))
-                .then(options)
-                .executes(command));
+    private ArgumentBuilder<CommandSourceStack, ?> options() {
+        final var options = new HashMap<String, @Nullable ArgumentType<?>>();
+        options.put("dimension", new DimensionArgumentType(plugin));
+        options.put("generator", new GeneratorArgument(plugin));
+        options.put("--void-world", null);
+        return Commands.argument("options", new CommandOptionsArgument(options)).executes(this);
     }
 
     @Override
@@ -56,8 +68,6 @@ final class WorldImportCommand extends SimpleCommand {
 
         final var options = tryGetArgument(context, "options", CommandOptionsArgument.Options.class)
                 .orElseGet(CommandOptionsArgument.Options::new);
-        final var generatorType = options.getArgument("preset", Preset.class)
-                .map(GeneratorType.FLAT::with).orElse(null);
         final var dimension = options.getArgument("dimension", Dimension.class).orElse(null);
         final var generator = options.getArgument("generator", Generator.class).orElse(null);
 
@@ -69,13 +79,25 @@ final class WorldImportCommand extends SimpleCommand {
         }
 
         final var placeholder = Placeholder.parsed("world", key.asString());
-        plugin.bundle().sendMessage(sender, "world.import", placeholder);
 
-        final var build = Level.builder(key)
+        final var builder = Level.builder(key)
                 .generator(generator)
-                .generatorType(generatorType)
-                .dimension(dimension)
-                .build();
+                .dimension(dimension);
+        if (options.contains("--void-world")) builder
+                .generatorType(GeneratorType.FLAT.with(Preset.THE_VOID))
+                .ignoreLevelData(true);
+
+        final var source = tryGetArgument(context, "path", String.class)
+                .map(this::resolveSource);
+        if (source.isPresent()) try {
+            prepareSource(source.get(), builder);
+        } catch (final RuntimeException e) {
+            CommandFailureHandler.handle(plugin, sender, e, placeholder);
+            return 0;
+        }
+        final var build = builder.build();
+
+        plugin.bundle().sendMessage(sender, "world.import", placeholder);
 
         build.create().thenAccept(level -> {
             plugin.getWorldRegistry().register(build, true);
@@ -90,4 +112,49 @@ final class WorldImportCommand extends SimpleCommand {
 
         return SINGLE_SUCCESS;
     }
+
+    private Path resolveSource(final String input) {
+        final var path = Path.of(input);
+        if (path.isAbsolute() || path.getNameCount() != 1) throw new WorldOperationException(
+                WorldOperationException.Reason.WORLD_NOT_FOUND
+        ).path(path);
+        return plugin.getServer().getWorldContainer().toPath().resolve(path).normalize();
+    }
+
+    // todo: sorry future me but you have to clean up this mess :)
+    private void prepareSource(final Path source, final Level.Builder builder) {
+        if (!Files.isDirectory(source)) throw new WorldOperationException(
+                WorldOperationException.Reason.WORLD_NOT_FOUND
+        ).path(source);
+
+        final var level = builder.build();
+        final var target = level.getDirectory();
+        final var normalizedSource = source.toAbsolutePath().normalize();
+        if (normalizedSource.equals(plugin.getServer().getLevelDirectory().toAbsolutePath().normalize()))
+            throw new WorldOperationException(WorldOperationException.Reason.WORLD_DIRECTORY_LOADED).path(source);
+        if (plugin.getServer().getWorlds().stream()
+                .map(world -> world.getWorldPath().toAbsolutePath().normalize())
+                .anyMatch(normalizedSource::equals))
+            throw new WorldOperationException(WorldOperationException.Reason.WORLD_DIRECTORY_LOADED).path(source);
+        if (plugin.listLevels().map(path -> path.toAbsolutePath().normalize()).anyMatch(normalizedSource::equals))
+            throw new WorldOperationException(WorldOperationException.Reason.WORLD_PATH_EXISTS).path(source);
+        if (Files.exists(target) && !normalizedSource.equals(target.toAbsolutePath().normalize()))
+            throw new WorldOperationException(
+                    Files.isDirectory(target)
+                            ? WorldOperationException.Reason.WORLD_PATH_EXISTS
+                            : WorldOperationException.Reason.TARGET_PATH_IS_FILE
+            ).path(target);
+
+        if (!isLegacyWorld(source)) throw new WorldOperationException(
+                WorldOperationException.Reason.WORLD_NOT_FOUND
+        ).path(source);
+
+        builder.legacyName(source.getFileName().toString());
+    }
+
+    private boolean isLegacyWorld(final Path source) {
+        return Files.isRegularFile(source.resolve("level.dat"))
+                || Files.isRegularFile(source.resolve("level.dat_old"));
+    }
+
 }

--- a/plugin/src/main/java/net/thenextlvl/worlds/command/WorldListCommand.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/command/WorldListCommand.java
@@ -12,16 +12,20 @@ import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.thenextlvl.worlds.Dimension;
 import net.thenextlvl.worlds.WorldsPlugin;
 import net.thenextlvl.worlds.command.brigadier.SimpleCommand;
+import net.thenextlvl.worlds.view.PaperLevelView;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -43,15 +47,17 @@ final class WorldListCommand extends SimpleCommand {
         final var worlds = plugin.getServer().getWorlds();
 
         final var entries = new ArrayList<WorldListEntry>();
-        worlds.forEach(world -> entries.add(new WorldListEntry(world.key(), plugin.handler().getDimension(world), State.LOADED)));
+        worlds.forEach(world -> entries.add(new WorldListEntry(world.key(), plugin.handler().getDimension(world), State.LOADED, null)));
         plugin.getWorldRegistry().entrySet()
                 .filter(entry -> plugin.getServer().getWorld(entry.getKey()) == null)
-                .forEach(entry -> entries.add(new WorldListEntry(entry.getKey(), entry.getValue().dimension(), State.UNLOADED)));
+                .forEach(entry -> entries.add(new WorldListEntry(entry.getKey(), entry.getValue().dimension(), State.UNLOADED, null)));
 
-        listUnimported(worlds.stream().map(World::getWorldPath).toList(), plugin.listLevels().toList())
-                .map(path -> plugin.levelView().key(path).orElse(null))
+        listUnimported(
+                worlds.stream().map(World::getWorldPath).map(path -> path.toAbsolutePath().normalize()).toList(),
+                plugin.listLevels().map(path -> path.toAbsolutePath().normalize()).toList()
+        ).map(path -> unimportedEntry(path).orElse(null))
                 .filter(Objects::nonNull)
-                .forEach(key -> entries.add(new WorldListEntry(key, null, State.UNIMPORTED)));
+                .forEach(entries::add);
 
         plugin.bundle().sendMessage(sender, "world.list.header",
                 Placeholder.parsed("worlds", String.valueOf(count(entries, State.LOADED))),
@@ -59,7 +65,7 @@ final class WorldListCommand extends SimpleCommand {
                 Placeholder.parsed("unimported", String.valueOf(count(entries, State.UNIMPORTED))));
         entries.stream()
                 .sorted()
-                .collect(Collectors.groupingBy(entry -> entry.key().namespace(), TreeMap::new, Collectors.toList()))
+                .collect(Collectors.groupingBy(this::namespace, TreeMap::new, Collectors.toList()))
                 .forEach((key, value) -> {
                     plugin.bundle().sendMessage(sender, "world.list.namespace",
                             Placeholder.parsed("namespace", key),
@@ -72,11 +78,92 @@ final class WorldListCommand extends SimpleCommand {
         return SINGLE_SUCCESS;
     }
 
+    private String namespace(final WorldListEntry entry) {
+        if (!entry.state().equals(State.UNIMPORTED) || entry.importPath() == null || isModernLevelPath(entry.importPath())
+                || isLegacyWorld(entry.importPath()))
+            return entry.key().namespace();
+        final var root = plugin.getServer().getWorldContainer().toPath().toAbsolutePath().normalize();
+        final var parent = entry.importPath().toAbsolutePath().normalize().getParent();
+        if (parent == null || parent.equals(root)) return ".";
+        return root.relativize(parent).toString();
+    }
+
     private Stream<Path> listUnimported(final List<Path> loadedFolders, final List<Path> managedFolders) {
-        return plugin.levelView().listLevelFolders().stream()
+        return Stream.concat(plugin.levelView().listLevelFolders().stream(), listRootLevelFolders())
+                .map(path -> path.toAbsolutePath().normalize())
                 .filter(path -> !loadedFolders.contains(path))
                 .filter(path -> !managedFolders.contains(path));
     }
+
+    // todo: sorry future me but you have to clean up this mess :)
+    private Stream<Path> listRootLevelFolders() {
+        final var root = plugin.getServer().getWorldContainer().toPath();
+        final var serverLevel = plugin.getServer().getLevelDirectory().toAbsolutePath().normalize();
+        final var dimensions = plugin.getDimensionsRoot().toAbsolutePath().normalize();
+        try (final var paths = Files.walk(root)) {
+            return paths.filter(Files::isDirectory)
+                    .filter(path -> !path.equals(root))
+                    .filter(path -> {
+                        final var normalized = path.toAbsolutePath().normalize();
+                        return !normalized.equals(serverLevel) && !normalized.startsWith(dimensions);
+                    })
+                    .filter(this::looksLikeWorld)
+                    .toList().stream();
+        } catch (final IOException e) {
+            return Stream.empty();
+        }
+    }
+
+    private boolean looksLikeWorld(final Path path) {
+        return Files.isDirectory(path.resolve("region"))
+                || Files.isRegularFile(path.resolve("level.dat"))
+                || Files.isRegularFile(path.resolve("level.dat_old"));
+    }
+
+    private Optional<WorldListEntry> unimportedEntry(final Path path) {
+        if (isLegacyWorld(path)) return legacyEntry(path);
+        final var key = key(path).orElse(null);
+        if (key != null) return plugin.getWorldRegistry().isRegistered(key)
+                ? Optional.empty()
+                : Optional.of(new WorldListEntry(key, null, State.UNIMPORTED, isModernLevelPath(path) ? null : path));
+        return Optional.ofNullable(path.getFileName())
+                .map(Path::toString)
+                .map(PaperLevelView::createKey)
+                .filter(value -> !value.isBlank())
+                .map(value -> plugin.levelView().findFreeKey("worlds", value))
+                .map(fallback -> new WorldListEntry(fallback, null, State.UNIMPORTED, path));
+    }
+
+    private Optional<WorldListEntry> legacyEntry(final Path path) {
+        return plugin.legacyWorldRegistry().read(path)
+                .filter(data -> !plugin.getWorldRegistry().isRegistered(data.key()))
+                .map(data -> new WorldListEntry(data.key(), null, State.UNIMPORTED, path));
+    }
+
+    private Optional<Key> key(final Path path) {
+        final var root = plugin.getServer().getWorldContainer().toPath().toAbsolutePath().normalize();
+        final var absolute = path.toAbsolutePath().normalize();
+        final var relative = absolute.startsWith(root) ? root.relativize(absolute) : absolute;
+        return plugin.levelView().key(absolute)
+                .or(() -> plugin.levelView().lenientKey(absolute))
+                .or(() -> plugin.levelView().lenientKey(relative))
+                .or(() -> plugin.levelView().lenientKey(lastTwoSegments(absolute)));
+    }
+
+    private boolean isLegacyWorld(final Path path) {
+        return Files.isRegularFile(path.resolve("level.dat"))
+                || Files.isRegularFile(path.resolve("level.dat_old"));
+    }
+
+    private Path lastTwoSegments(final Path path) {
+        final var count = path.getNameCount();
+        return count > 2 ? path.subpath(count - 2, count) : path;
+    }
+
+    private boolean isModernLevelPath(final Path path) {
+        return path.toAbsolutePath().normalize().startsWith(plugin.getDimensionsRoot().toAbsolutePath().normalize());
+    }
+    // todo: cleanup end
 
     private long count(final Iterable<WorldListEntry> entries, final State state) {
         var count = 0;
@@ -111,7 +198,7 @@ final class WorldListCommand extends SimpleCommand {
     }
 
     private record WorldListEntry(Key key, @Nullable Dimension dimension,
-                                  State state) implements Comparable<WorldListEntry> {
+                                  State state, @Nullable Path importPath) implements Comparable<WorldListEntry> {
         private static final Comparator<WorldListEntry> COMPARATOR = Comparator
                 .comparing((WorldListEntry entry) -> entry.key.namespace())
                 .thenComparing(entry -> entry.state)
@@ -134,7 +221,24 @@ final class WorldListCommand extends SimpleCommand {
             return plugin.bundle().component(state.translationKey, sender, placeholders)
                     .hoverEvent(HoverEvent.showText(plugin.bundle().component(state.hoverKey, sender,
                             Placeholder.parsed("world", key))))
-                    .clickEvent(ClickEvent.suggestCommand(state.command + key + suffix));
+                    .clickEvent(ClickEvent.suggestCommand(command(plugin) + suffix));
+        }
+
+        private String command(final WorldsPlugin plugin) {
+            if (!state.equals(State.UNIMPORTED) || importPath == null) return state.command + key().asString();
+            final var root = plugin.getServer().getWorldContainer().toPath().toAbsolutePath().normalize();
+            final var path = root.relativize(importPath.toAbsolutePath().normalize()).toString();
+            final var command = new StringBuilder(state.command)
+                    .append("\"")
+                    .append(path.replace("\\", "\\\\").replace("\"", "\\\""))
+                    .append("\" ")
+                    .append(key().asString());
+            plugin.legacyWorldRegistry().read(importPath).ifPresent(data -> {
+                command.append(" dimension ").append(data.dimension().key().asString());
+                final var generator = data.generator();
+                if (generator != null) command.append(" generator ").append(generator);
+            });
+            return command.toString();
         }
 
         private Component label() {

--- a/plugin/src/main/java/net/thenextlvl/worlds/command/suggestion/WorldKeyImportSuggestionProvider.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/command/suggestion/WorldKeyImportSuggestionProvider.java
@@ -15,10 +15,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 @NullMarked
-public final class WorldImportSuggestionProvider implements SuggestionProvider<CommandSourceStack> {
+public final class WorldKeyImportSuggestionProvider implements SuggestionProvider<CommandSourceStack> {
     private final WorldsPlugin plugin;
 
-    public WorldImportSuggestionProvider(final WorldsPlugin plugin) {
+    public WorldKeyImportSuggestionProvider(final WorldsPlugin plugin) {
         this.plugin = plugin;
     }
 

--- a/plugin/src/main/java/net/thenextlvl/worlds/command/suggestion/WorldPathImportSuggestionProvider.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/command/suggestion/WorldPathImportSuggestionProvider.java
@@ -1,0 +1,37 @@
+package net.thenextlvl.worlds.command.suggestion;
+
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import net.thenextlvl.worlds.WorldsPlugin;
+import org.jspecify.annotations.NullMarked;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+@NullMarked
+public final class WorldPathImportSuggestionProvider implements SuggestionProvider<CommandSourceStack> {
+    private final WorldsPlugin plugin;
+
+    public WorldPathImportSuggestionProvider(final WorldsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public CompletableFuture<Suggestions> getSuggestions(final CommandContext<CommandSourceStack> context, final SuggestionsBuilder builder) {
+        plugin.legacyWorldRegistry().listPaths(plugin.getServer().getWorldContainer().toPath())
+                .map(path -> path.toAbsolutePath().normalize())
+                .map(this::suggestion)
+                .map(s -> "\"" + s + "\"")
+                .filter(s -> s.contains(builder.getRemaining()))
+                .forEach(builder::suggest);
+        return builder.buildFuture();
+    }
+
+    private String suggestion(final Path path) {
+        final var root = plugin.getServer().getWorldContainer().toPath().toAbsolutePath().normalize();
+        return path.equals(root) ? root.toString() : root.relativize(path).toString();
+    }
+}

--- a/plugin/src/main/java/net/thenextlvl/worlds/command/suggestion/WorldPathKeyImportSuggestionProvider.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/command/suggestion/WorldPathKeyImportSuggestionProvider.java
@@ -1,0 +1,64 @@
+package net.thenextlvl.worlds.command.suggestion;
+
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import net.kyori.adventure.key.Key;
+import net.thenextlvl.worlds.LegacyWorldRegistry;
+import net.thenextlvl.worlds.WorldsPlugin;
+import net.thenextlvl.worlds.view.PaperLevelView;
+import org.jspecify.annotations.NullMarked;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+@NullMarked
+// todo: sorry future me but you have to clean up this mess :)
+public final class WorldPathKeyImportSuggestionProvider implements SuggestionProvider<CommandSourceStack> {
+    private final WorldsPlugin plugin;
+
+    public WorldPathKeyImportSuggestionProvider(final WorldsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public CompletableFuture<Suggestions> getSuggestions(final CommandContext<CommandSourceStack> context, final SuggestionsBuilder builder) {
+        suggestedKey(context)
+                .map(plugin.levelView()::findFreeKey)
+                .map(Key::asString)
+                .filter(s -> s.contains(builder.getRemaining()))
+                .ifPresent(builder::suggest);
+        return builder.buildFuture();
+    }
+
+    private Optional<Key> suggestedKey(final CommandContext<?> context) {
+        final var source = resolveSource(context.getArgument("path", String.class));
+        return legacyKey(source)
+                .or(() -> key(source))
+                .or(() -> Optional.ofNullable(source.getFileName())
+                        .map(Path::toString)
+                        .map(PaperLevelView::createKey)
+                        .filter(value -> !value.isBlank())
+                        .map(value -> Key.key("worlds", value)));
+    }
+
+    private Optional<Key> key(final Path source) {
+        final var root = plugin.getServer().getWorldContainer().toPath().toAbsolutePath().normalize();
+        final var absolute = source.toAbsolutePath().normalize();
+        final var directory = absolute.startsWith(root) ? root.relativize(absolute) : absolute;
+        return plugin.levelView().lenientKey(absolute)
+                .or(() -> plugin.levelView().lenientKey(directory));
+    }
+
+    private Optional<Key> legacyKey(final Path source) {
+        return plugin.legacyWorldRegistry().read(source).map(LegacyWorldRegistry.LegacyWorldData::key);
+    }
+
+    private Path resolveSource(final String input) {
+        final var path = Path.of(input);
+        return plugin.getServer().getWorldContainer().toPath().resolve(path).normalize();
+    }
+}

--- a/plugin/src/main/java/net/thenextlvl/worlds/listener/WorldListener.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/listener/WorldListener.java
@@ -2,8 +2,11 @@ package net.thenextlvl.worlds.listener;
 
 import net.kyori.adventure.key.Key;
 import net.thenextlvl.worlds.Dimension;
+import net.thenextlvl.worlds.Level;
 import net.thenextlvl.worlds.WorldRegistry;
 import net.thenextlvl.worlds.WorldsPlugin;
+import net.thenextlvl.worlds.generator.Generator;
+import net.thenextlvl.worlds.generator.GeneratorException;
 import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -11,6 +14,14 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 
 public final class WorldListener implements Listener {
     private final WorldsPlugin plugin;
@@ -30,8 +41,10 @@ public final class WorldListener implements Listener {
         }
 
         if (!plugin.levelView().isOverworld(event.getWorld())) return;
+        final var migrating = migrateLegacyWorlds();
         plugin.getWorldRegistry().entrySet()
                 .filter(entry -> entry.getValue().enabled())
+                .filter(entry -> !migrating.contains(entry.getKey()))
                 .forEach(entry -> loadLevel(entry.getKey(), entry.getValue()));
     }
 
@@ -56,17 +69,80 @@ public final class WorldListener implements Listener {
                 "Loaded dimension {} ({}) from {}",
                 world.key().asString(), level.getGeneratorType().key().asString(),
                 world.getWorldPath()
-        )).exceptionally(throwable -> {
-            final var t = throwable.getCause() != null ? throwable.getCause() : throwable;
-            if (plugin.handler().isDirectoryLockException(t)) {
-                plugin.getComponentLogger().error("Failed to start the minecraft server", t);
-                plugin.getServer().shutdown();
-            } else {
-                plugin.getComponentLogger().error("An unexpected error occurred while loading the level {}", key, t);
-                plugin.getComponentLogger().error("Please report the error above on GitHub: {}", WorldsPlugin.ISSUES);
-            }
-            return null;
-        });
+        )).exceptionally(throwable -> handleCreationException(throwable, key));
     }
 
+    private Set<Key> migrateLegacyWorlds() {
+        final var migrating = new HashSet<Key>();
+        final var root = plugin.getServer().getWorldContainer().toPath();
+        if (!Files.isDirectory(root)) return migrating;
+        try (final var files = Files.list(root)) {
+            files.filter(Files::isDirectory)
+                    .filter(path -> !path.equals(plugin.getServer().getLevelDirectory()))
+                    .map(this::migrateLegacyWorld)
+                    .filter(Objects::nonNull)
+                    .forEach(migrating::add);
+        } catch (final IOException e) {
+            plugin.getComponentLogger().warn("Failed to scan legacy worlds in {}", root, e);
+        }
+        return migrating;
+    }
+
+    private @Nullable Key migrateLegacyWorld(final Path path) {
+        final var data = plugin.legacyWorldRegistry().read(path).orElse(null);
+        if (data == null) return null;
+
+        // todo: does this make sense? it works I guess; no time to double check. future me problem now :)
+        final var existing = plugin.getServer().getWorld(data.key());
+        if (existing != null) {
+            if (!plugin.getWorldRegistry().isRegistered(data.key()))
+                plugin.getComponentLogger().warn("Refusing to migrate legacy world {}, a world with the same key ({}) already exists", path, data.key());
+            return null;
+        }
+        // todo end
+
+        try {
+            final var generator = data.generator() != null ? Generator.fromString(data.generator()) : null;
+            if (!plugin.getWorldRegistry().registerIfAbsent(
+                    data.key(), data.dimension(), data.enabled(), generator
+            )) return null;
+            if (!data.enabled()) return null;
+
+            plugin.handler().warnAndDelayStartupMigration();
+
+            final var level = Level.builder(data.key())
+                    .dimension(data.dimension())
+                    .generator(generator)
+                    .legacyName(path.getFileName().toString())
+                    .build();
+
+            level.create().thenAccept(world -> {
+                plugin.getComponentLogger().debug(
+                        "Migrated legacy world {} ({}) from {}",
+                        world.key().asString(), level.getGeneratorType().key().asString(), path
+                );
+            }).exceptionally(throwable -> handleCreationException(throwable, level.key()));
+        } catch (final GeneratorException e) {
+            plugin.getComponentLogger().warn("Failed to migrate legacy world {}", data.key());
+            plugin.getComponentLogger().warn("{}: {}", e.getClass().getName(), e.getMessage());
+        } catch (final Exception e) {
+            plugin.getComponentLogger().error("An unexpected error occurred while migrating the legacy world {}", data.key(), e);
+            plugin.getComponentLogger().error("Please report the error above on GitHub: {}", WorldsPlugin.ISSUES);
+            WorldsPlugin.ERROR_TRACKER.trackError(e);
+        }
+        return data.key();
+    }
+
+    private <T> @Nullable T handleCreationException(final Throwable throwable, final Key key) {
+        final var t = throwable.getCause() != null ? throwable.getCause() : throwable;
+        if (plugin.handler().isDirectoryLockException(t)) {
+            plugin.getComponentLogger().error("Failed to start the minecraft server", t);
+            plugin.getServer().shutdown();
+        } else {
+            plugin.getComponentLogger().error("An unexpected error occurred while loading the level {}", key, t);
+            plugin.getComponentLogger().error("Please report the error above on GitHub: {}", WorldsPlugin.ISSUES);
+            WorldsPlugin.ERROR_TRACKER.trackError(t);
+        }
+        return null;
+    }
 }

--- a/plugin/src/main/java/net/thenextlvl/worlds/view/PaperLevelView.java
+++ b/plugin/src/main/java/net/thenextlvl/worlds/view/PaperLevelView.java
@@ -103,10 +103,12 @@ public class PaperLevelView {
                 .generator(entry.generator());
     }
 
+    // todo: sorry future me but you have to clean up this duplicate code :)
     @SuppressWarnings("PatternValidation")
     public Optional<Key> key(final Path directory) {
-        final var dimensions = plugin.getDimensionsRoot();
-        final var relative = directory.startsWith(dimensions) ? dimensions.relativize(directory) : directory;
+        final var dimensions = plugin.getDimensionsRoot().toAbsolutePath().normalize();
+        final var absolute = directory.toAbsolutePath().normalize();
+        final var relative = absolute.startsWith(dimensions) ? dimensions.relativize(absolute) : directory;
 
         if (relative.getNameCount() != 2) return Optional.empty();
 
@@ -118,6 +120,23 @@ public class PaperLevelView {
 
         return Optional.of(Key.key(namespace, value));
     }
+
+    public Optional<Key> lenientKey(final Path directory) {
+        final var dimensions = plugin.getDimensionsRoot().toAbsolutePath().normalize();
+        final var absolute = directory.toAbsolutePath().normalize();
+        final var relative = absolute.startsWith(dimensions) ? dimensions.relativize(absolute) : directory;
+
+        if (relative.getNameCount() != 2) return Optional.empty();
+
+        final var namespace = createKey(relative.getName(0).toString());
+        if (namespace.isBlank() || !namespace.matches("[a-z0-9_\\-.]+")) return Optional.empty();
+
+        final var value = createKey(relative.getName(1).toString());
+        if (value.isBlank() || !value.matches("[a-z0-9_\\-./]+")) return Optional.empty();
+
+        return Optional.of(Key.key(namespace, value));
+    }
+    // todo: cleanup end
 
     public Stream<Path> listLevels() {
         return plugin.getWorldRegistry().worlds()

--- a/version-specifics/src/main/java/net/thenextlvl/worlds/versions/VersionHandler.java
+++ b/version-specifics/src/main/java/net/thenextlvl/worlds/versions/VersionHandler.java
@@ -60,6 +60,8 @@ public abstract class VersionHandler {
 
     public abstract Dimension getDimension(World world);
 
+    public abstract void warnAndDelayStartupMigration();
+
     public Optional<FoliaSupport> foliaSupport() {
         return Optional.ofNullable(foliaSupport);
     }

--- a/version-specifics/v26.1.2/src/main/java/net/thenextlvl/worlds/versions/v26_1_2/SimpleFoliaSupport.java
+++ b/version-specifics/v26.1.2/src/main/java/net/thenextlvl/worlds/versions/v26_1_2/SimpleFoliaSupport.java
@@ -1,6 +1,9 @@
 package net.thenextlvl.worlds.versions.v26_1_2;
 
 import ca.spottedleaf.moonrise.patches.chunk_system.io.MoonriseRegionFileIO;
+import io.papermc.paper.FeatureHooks;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
 import net.thenextlvl.worlds.versions.FoliaSupport;
 import net.thenextlvl.worlds.versions.PluginAccess;
 import org.bukkit.World;
@@ -42,7 +45,7 @@ public class SimpleFoliaSupport extends FoliaSupport {
         return flush ? saved.thenCompose(ignored -> flushAsync(level)) : saved;
     }
 
-    private CompletableFuture<@Nullable Void> flushAsync(final net.minecraft.server.level.ServerLevel level) {
+    private CompletableFuture<@Nullable Void> flushAsync(final ServerLevel level) {
         final var future = new CompletableFuture<@Nullable Void>();
         plugin.getServer().getAsyncScheduler().runNow(plugin, task -> {
             try {
@@ -62,7 +65,7 @@ public class SimpleFoliaSupport extends FoliaSupport {
         final var server = ((CraftServer) plugin.getServer());
 
         if (server.getServer().getLevel(handle.dimension()) == null) return false;
-        if (handle.dimension() == net.minecraft.world.level.Level.OVERWORLD) return false;
+        if (handle.dimension() == Level.OVERWORLD) return false;
         return handle.players().isEmpty();
     }
 
@@ -75,7 +78,7 @@ public class SimpleFoliaSupport extends FoliaSupport {
             final var handle = ((CraftWorld) world).getHandle();
             markNonSchedulable(handle);
             handle.getChunkSource().close(false);
-            io.papermc.paper.FeatureHooks.closeEntityManager(handle, save);
+            FeatureHooks.closeEntityManager(handle, save);
         } catch (final Exception e) {
             throw new RuntimeException("Failed to close world", e);
         }
@@ -89,7 +92,7 @@ public class SimpleFoliaSupport extends FoliaSupport {
         markNonSchedulable(handle);
     }
 
-    private void markNonSchedulable(final net.minecraft.server.level.ServerLevel handle) {
+    private void markNonSchedulable(final ServerLevel handle) {
         handle.regioniser.computeForAllRegionsUnsynchronised(regionThread -> {
             if (regionThread.getData().world != handle) return;
             regionThread.getData().getRegionSchedulingHandle().markNonSchedulable();

--- a/version-specifics/v26.1.2/src/main/java/net/thenextlvl/worlds/versions/v26_1_2/SimpleVersionHandler.java
+++ b/version-specifics/v26.1.2/src/main/java/net/thenextlvl/worlds/versions/v26_1_2/SimpleVersionHandler.java
@@ -118,7 +118,6 @@ public final class SimpleVersionHandler extends VersionHandler {
      * @see ServerLevel#saveLevelData(boolean)
      */
     @Override
-    @SuppressWarnings("JavadocReference")
     public CompletableFuture<@Nullable Void> saveLevelDataAsync(final World world) {
         final var level = ((CraftWorld) world).getHandle();
         final SavedDataStorage savedDataStorage = level.getChunkSource().getDataStorage();
@@ -227,11 +226,13 @@ public final class SimpleVersionHandler extends VersionHandler {
                     WorldOperationException.Reason.MISSING_LEVEL_STEM
             )); // Worlds - complete exceptionally
         }
-        try {
+        // Worlds - legacy world migration
+        final var legacyName = level.legacyName().orElse(null);
+        if (legacyName != null) try {
             WorldFolderMigration.migrateApiWorld(
                     console.storageSource,
                     console.registryAccess(),
-                    name,
+                    legacyName,
                     actualDimension,
                     dimensionKey
             );
@@ -239,15 +240,22 @@ public final class SimpleVersionHandler extends VersionHandler {
             return CompletableFuture.failedFuture(new WorldOperationException(
                     WorldOperationException.Reason.LEGACY_MIGRATION_FAILED,
                     ex
-            )); // Worlds - complete exceptionally
+            ));
         }
+        // Worlds end
         PaperWorldLoader.LoadedWorldData loadedWorldData = PaperWorldLoader.loadWorldData(
                 console,
                 dimensionKey,
                 name
         );
+
+        // Worlds - remove legacy pdc keys
+        if (legacyName != null && loadedWorldData.pdc() != null) removeLegacyPdcKeys(loadedWorldData.pdc());
+        // Worlds end
+
         final PrimaryLevelData primaryLevelData = (PrimaryLevelData) console.getWorldData();
-        WorldGenSettings worldGenSettings = LevelStorageSource.readExistingSavedData(console.storageSource, dimensionKey, console.registryAccess(), WorldGenSettings.TYPE)
+        WorldGenSettings worldGenSettings = level.ignoreLevelData() ? null // Worlds - ignore level data
+                : LevelStorageSource.readExistingSavedData(console.storageSource, dimensionKey, console.registryAccess(), WorldGenSettings.TYPE)
                 .result()
                 .orElse(null);
 
@@ -376,6 +384,17 @@ public final class SimpleVersionHandler extends VersionHandler {
         console.prepareLevel(serverLevel);
 
         return CompletableFuture.completedFuture(serverLevel.getWorld());
+    }
+
+    private void removeLegacyPdcKeys(final PaperWorldPDC pdc) {
+        final var data = pdc.persistentData();
+        data.remove(new NamespacedKey("worlds", "link_nether"));
+        data.remove(new NamespacedKey("worlds", "link_end"));
+        data.remove(new NamespacedKey("worlds", "enabled"));
+        data.remove(new NamespacedKey("worlds", "world_key"));
+        data.remove(new NamespacedKey("worlds", "generator"));
+        data.remove(new NamespacedKey("worlds", "dimension"));
+        pdc.setDirty();
     }
 
     private Key getGeneratorTypeName(final GeneratorType generatorType) {

--- a/version-specifics/v26.1.2/src/main/java/net/thenextlvl/worlds/versions/v26_1_2/SimpleVersionHandler.java
+++ b/version-specifics/v26.1.2/src/main/java/net/thenextlvl/worlds/versions/v26_1_2/SimpleVersionHandler.java
@@ -485,6 +485,11 @@ public final class SimpleVersionHandler extends VersionHandler {
         return new Dimension(fromIdentifier(identifier));
     }
 
+    @Override
+    public void warnAndDelayStartupMigration() {
+        WorldFolderMigration.warnAndDelayStartupMigration();
+    }
+
     @SuppressWarnings("PatternValidation")
     private Key fromIdentifier(final Identifier identifier) {
         return Key.key(identifier.getNamespace(), identifier.getPath());

--- a/version-specifics/v26.1.2/src/main/java/net/thenextlvl/worlds/versions/v26_1_2/SimpleVersionHandler.java
+++ b/version-specifics/v26.1.2/src/main/java/net/thenextlvl/worlds/versions/v26_1_2/SimpleVersionHandler.java
@@ -87,7 +87,7 @@ import java.util.stream.Stream;
 
 public final class SimpleVersionHandler extends VersionHandler {
     public SimpleVersionHandler(final PluginAccess plugin) {
-        super(plugin, new SimpleFoliaSupport(plugin), true);
+        super(plugin, plugin.isRunningFolia() ? new SimpleFoliaSupport(plugin) : null, true);
     }
 
     @Override


### PR DESCRIPTION
# Changes
- Added migration support to import command
  `/world import <path> <key> [<options>]`
- Added automatic startup migration for worlds created by previous versions of Worlds
- `/world list` now also shows unmigrated legacy worlds (with click action)

# _Small_ breaking changes
- `WorldRegistry#registerIfAbsent` now returns a boolean
- Replaced `preset` option for `/world import` with `--void-world` _as it was the only use-case for the option anyway_

_This update breaks semver_ :shushing_face: 
Docs update is required as well